### PR TITLE
feat(types): narrower identify types + deltaE doc fix

### DIFF
--- a/src/identify.ts
+++ b/src/identify.ts
@@ -5,7 +5,7 @@ import type { X11ColorName } from './colorspaces/x11';
 import { toRgba } from './convert';
 import { detectFormat } from './detectFormat';
 import { nearest } from './indexing';
-import type { ColorspaceName, DistanceMetric } from './types';
+import type { ColorInput, ColorspaceName, DistanceMetric } from './types';
 
 type ColorNameByColorspace = {
   web: WebColorName;
@@ -27,7 +27,7 @@ type ColorNameByColorspace = {
  * Defaults: colorspace = 'web', metric = DEFAULT_METRICS[colorspace].
  */
 export function identify<C extends ColorspaceName = 'web'>(
-  input: Parameters<typeof toRgba>[0],
+  input: ColorInput,
   opts: { colorspace?: C; metric?: DistanceMetric } = {},
 ): ColorNameByColorspace[C] | null {
   const format = detectFormat(input);

--- a/src/identify.ts
+++ b/src/identify.ts
@@ -1,8 +1,17 @@
+import type { PantoneColorName } from './colorspaces/pantone';
 import { COLORSPACE_NAMES, COLORSPACES, DEFAULT_METRICS } from './colorspaces/registry';
+import type { WebColorName } from './colorspaces/web';
+import type { X11ColorName } from './colorspaces/x11';
 import { toRgba } from './convert';
 import { detectFormat } from './detectFormat';
 import { nearest } from './indexing';
 import type { ColorspaceName, DistanceMetric } from './types';
+
+type ColorNameByColorspace = {
+  web: WebColorName;
+  x11: X11ColorName;
+  pantone: PantoneColorName;
+};
 
 /**
  * Identify the nearest-named color for any color input.
@@ -17,17 +26,17 @@ import type { ColorspaceName, DistanceMetric } from './types';
  *
  * Defaults: colorspace = 'web', metric = DEFAULT_METRICS[colorspace].
  */
-export function identify(
+export function identify<C extends ColorspaceName = 'web'>(
   input: Parameters<typeof toRgba>[0],
-  opts: { colorspace?: ColorspaceName; metric?: DistanceMetric } = {},
-): string | null {
+  opts: { colorspace?: C; metric?: DistanceMetric } = {},
+): ColorNameByColorspace[C] | null {
   const format = detectFormat(input);
   if (format === 'UNKNOWN') return null;
 
-  const { colorspace = 'web', metric } = opts;
+  const colorspace = (opts.colorspace ?? 'web') as C;
   if (!COLORSPACE_NAMES.has(colorspace)) return null;
 
   const rgba = toRgba(input, format);
-  const name = nearest(rgba, COLORSPACES[colorspace], metric ?? DEFAULT_METRICS[colorspace]);
-  return name || null;
+  const name = nearest(rgba, COLORSPACES[colorspace], opts.metric ?? DEFAULT_METRICS[colorspace]);
+  return (name as ColorNameByColorspace[C]) || null;
 }

--- a/src/math/deltaE.ts
+++ b/src/math/deltaE.ts
@@ -1,9 +1,12 @@
 /**
- * CIE color-difference metrics. Inputs are `Lab` triples (L, a, b) as
- * produced by `rgbaToLab` from `colorSpace.ts`.
+ * Color-difference metrics. Inputs are `Lab` triples (L, a, b). The
+ * CIELAB family (ΔE*76 / ΔE*94 / ΔE*00) takes coordinates from
+ * `rgbaToLab`; ΔE*ok takes coordinates from `rgbaToOklab`. Both spaces
+ * share the `Lab` tuple shape but are not interchangeable — see
+ * `deltaEokSquared` below.
  *
- * All three metrics operate in CIELAB; the differences are in how each
- * region of Lab space is weighted:
+ * Within the CIELAB family, the metrics differ in how each region of
+ * Lab space is weighted:
  *   ΔE*76  — simple Euclidean in Lab (CIE 1976). Fast, decent.
  *   ΔE*94  — adds chroma/hue weighting (CIE 1994). Better saturation handling.
  *   ΔE00  — also adjusts L/C/h + rotation correction in blue-purple region


### PR DESCRIPTION
## Summary
Three small cleanups I noticed after the 1.3.1 republish — landing as three focused commits.

- **`feat(types)`**: `identify` is now generic over `ColorspaceName`, so `identify(x, { colorspace: 'pantone' })` returns `PantoneColorName | null` (not flat `string | null`). Pure type change; all narrower types are assignable to the old `string | null`, so existing consumers are unaffected. Should trigger a minor bump → 1.4.0.
- **`docs(math)`**: `deltaE.ts` header said "all three metrics operate in CIELAB", but ΔE*ok (added later) is in OKLAB. Scoped the weighting explanation to the CIELAB family and clarified that `Lab` is a shared tuple shape, not a shared colorspace.
- **`refactor(identify)`**: replaced `Parameters<typeof toRgba>[0]` with a direct `ColorInput` import — that's the name we use everywhere else for this union.

Deliberately **not** touching `safeStringify` in `convert.ts` — it earns its keep by producing useful error messages for malformed object inputs.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 297 pass
- [x] `bun run lint` clean
- [ ] CI green
- [ ] After merge, semantic-release cuts 1.4.0 from the `feat(types)` commit