### PR TITLE
fix: fix bundle-size badge + stale npm description

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Types: included](https://img.shields.io/npm/types/chromonym?color=3178c6&logo=typescript)](https://www.npmjs.com/package/chromonym)
 [![CI](https://github.com/simiancraft/chromonym/actions/workflows/ci.yml/badge.svg)](https://github.com/simiancraft/chromonym/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/simiancraft/chromonym?logo=codecov)](https://codecov.io/github/simiancraft/chromonym)
-[![Bundle size](https://img.shields.io/bundlephobia/minzip/chromonym?label=bundle%20size)](https://bundlephobia.com/package/chromonym)
+[![Bundle size](https://img.shields.io/badge/bundle-1.5--20%20kB%20gz-informational)](#what-you-actually-ship)
 
 <p align="center">
   <code>identify</code> &nbsp;•&nbsp; <code>resolve</code> &nbsp;•&nbsp; <code>convert</code>
@@ -451,17 +451,19 @@ const tryConvert = (input: ColorInput, opts = {}) => {
 
 ### What you actually ship
 
-The published tarball is **~557 kB gzipped / ~2.5 MB unpacked** because it carries twelve palettes and ~9000 named-color entries. That's the number `packagephobia` reports — it measures the install footprint on disk. Your **bundle** pays only for what you actually import, measured with `esbuild --minify`:
+**Install size and bundle size are not the same number.** Install size is what lands in your `node_modules/` after `npm install`; bundle size is what ships to your users after tree-shaking, minification, and gzip. For chromonym the gap is roughly two orders of magnitude.
+
+The published tarball is **~2.5 MB unpacked / ~557 kB gzipped** because it carries twelve palettes and ~9000 named-color entries; that's the install-size figure `packagephobia` reports. Your **production bundle** pays only for what you actually import, measured with `esbuild --minify`:
 
 | Import | min | gzip |
 |---|---|---|
-| `import { identify, web } from 'chromonym'` | 10.9 kB | **4.7 kB** |
-| `import { identify, pantone } from 'chromonym'` | 27 kB | **11.3 kB** |
-| `import { identify, ntc } from 'chromonym'` (one of the bigger palettes) | 43 kB | **20 kB** |
 | `import { defineColorPalette } from 'chromonym'` (pure BYO; no built-in) | 3.8 kB | **1.5 kB** |
+| `import { identify, web } from 'chromonym'` | 10.9 kB | **4.7 kB** |
 | `import { pantoneToRgba } from 'chromonym'` (single conversion) | 17.5 kB | **6.8 kB** |
+| `import { identify, pantone } from 'chromonym'` | 27 kB | **11.3 kB** |
+| `import { identify, ntc } from 'chromonym'` | 43 kB | **20 kB** |
 
-The install-size number is a shipping concern, not a bundle-size one. If you're evaluating chromonym against a size budget, the gzip column above is what actually lands in your production build.
+If you're evaluating chromonym against a size budget, the gzip column above is what actually lands in your production build.
 
 ## Types
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chromonym",
   "version": "3.2.0",
-  "description": "One color-naming API for any palette. Identify, resolve, and convert colors across your own palette or the built-in CSS, X11, Pantone, and Crayola sets — fully typed, tree-shakeable, perceptual distance metrics (CIEDE2000 / OKLAB).",
+  "description": "One color-naming API for any palette. Identify, resolve, and convert colors across your own palette or twelve built-in sets (CSS, X11, Pantone, Crayola, NTC, XKCD, Resene, NCS, ISCC-NBS, NBS, FS 595 B/C); fully typed, tree-shakeable, perceptual distance metrics (CIEDE2000 / OKLAB).",
   "keywords": [
     "color",
     "color-name",


### PR DESCRIPTION
## Summary

Two small docs/metadata fixes that should have landed with PR #14 but were split across the merge boundary.

1. **Bundle-size badge** currently points at bundlephobia, which reports ~17 kB for the whole-barrel bundle. Readers skim the badge, see 17 kB, and don't realize that's only a single worst-case scenario — the new 'What you actually ship' table below the hero has measurements from 1.5 kB (BYO only) up to 20 kB (identify + largest palette). Swap for a static \`bundle 1.5-20 kB gz\` shields.io badge that anchor-links to that table, so the click path lands in context. Also reorders the table smallest→largest and tightens the install-vs-bundle framing. Commit \`8fa93d3\` cherry-picked from the branch.

2. **package.json description** at line 4 still enumerated 'CSS, X11, Pantone, and Crayola' — pre-expansion copy from the v3.1.x days. Since v3.2.0 ships twelve built-ins, the npm-registry description should match.

## Test plan

- [x] \`bun run lint\` clean
- [x] README anchor \`#what-you-actually-ship\` resolves on GitHub render
- [x] Static badge URL renders: <https://img.shields.io/badge/bundle-1.5--20%20kB%20gz-informational>