### PR TITLE
chore: repo-hygiene pass; security, CI, supply-chain, community-health

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: the_simian0604

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+# Populates the "Sponsor" button on the GitHub repo sidebar.
 ko_fi: the_simian0604

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something in chromonym doesn't behave as documented.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. A reproducible example is by far the most useful thing you can include.
+
+        **Do not use this form for security issues.** See [SECURITY.md](https://github.com/simiancraft/chromonym/blob/main/SECURITY.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: chromonym version
+      description: Output of `npm ls chromonym` or the value from your lockfile.
+      placeholder: "3.2.0"
+    validations:
+      required: true
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Runtime
+      description: Node, Bun, Deno, or browser — and version.
+      placeholder: "Bun 1.3.13 / Node 22.4.0 / Chrome 128"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Smallest possible code snippet that triggers the bug. Inline is fine; a link to a gist or StackBlitz is better.
+      render: ts
+      placeholder: |
+        import { name } from 'chromonym';
+        console.log(name('#ff00ff'));
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include error messages and stack traces verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, adjacent attempts, suspected cause.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/simiancraft/chromonym/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories. Do not open a public issue.
+  - name: Question or usage help
+    url: https://github.com/simiancraft/chromonym#readme
+    about: Most usage questions are answered in the README. If it's not, open a discussion-style issue using one of the templates above.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest a capability or API addition.
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        chromonym aims for a small, coherent API. Features are evaluated against "does this earn its weight in the bundle and the docs?" — lead with the problem you're solving.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that chromonym doesn't let you do today? A concrete use case is far more useful than a proposed API.
+      placeholder: "I'm building X and need to Y. Today I have to work around it by Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the API look like? Pseudo-code is fine. If you're not sure, say so — the problem statement is what matters most.
+      render: ts
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other libraries, userland workarounds, or API shapes you've already ruled out.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Fits the project scope?
+      description: chromonym is a color-naming library. Perceptual metrics, palette operations, and conversions are in scope. General-purpose color manipulation (blending, gradients, CSS generation) usually is not.
+      options:
+        - label: I've read the README and believe this fits chromonym's scope.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Thanks for the PR. Keep this short — the diff does most of the talking.
+Conventional Commits: fix: patch · feat: minor · feat!: / BREAKING CHANGE: major · chore/docs/test/refactor/ci: no release.
+-->
+
+## Summary
+
+<!-- One or two sentences. What does this change and why? -->
+
+## Changes
+
+<!-- Bulleted list of meaningful changes. Link to any related issue with `Closes #NN`. -->
+
+-
+
+## Testing
+
+<!-- How did you verify this? `bun test` output, new tests added, manual reproduction, etc. -->
+
+## Checklist
+
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] Tests added or updated (or: no behavior change)
+- [ ] README / JSDoc updated if a public API changed (or: no public surface change)
+- [ ] `bun run lint && bun run typecheck && bun test` passes locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Least-privilege default for the whole workflow; the `release` job
+# overrides with a broader block for semantic-release to push tags.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+# OpenSSF Scorecard supply-chain-security analysis.
+# Runs weekly, on every push to main, and on branch-protection changes.
+# Results are published to:
+#   1. GitHub code-scanning (Security tab)
+#   2. The public scorecard.dev dashboard (powers the README badge)
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        with:
+          sarif_file: results.sarif

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repository.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-customization/customizing-your-repository/about-code-owners
+*       @the-simian

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at info@simiancraft.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to chromonym
+
+Thanks for considering a contribution. This project is small and opinionated; the bar for merging is high, but the review is friendly.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.3+ (package manager + test runner)
+- Node.js is not required to develop against this repo; Bun runs the TypeScript sources directly.
+
+## Setup
+
+```sh
+git clone https://github.com/simiancraft/chromonym.git
+cd chromonym
+bun install
+```
+
+## Common tasks
+
+| Task | Command |
+|---|---|
+| Run all tests | `bun test` |
+| Run a single test file | `bun test test/conversions/rgb.test.ts` |
+| Typecheck | `bun run typecheck` |
+| Lint | `bun run lint` |
+| Auto-fix lint | `bun run lint:fix` |
+| Format | `bun run format` |
+| Build the library | `bun run build` |
+| Run the demo app | `bun run demo` |
+| Validate npm packaging | `bun run check:package` |
+| Find unused exports | `bun run check:knip` |
+
+## Commit style
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/). `semantic-release` reads the commit log on every push to `main` and cuts patch/minor/major releases automatically — so the commit type matters:
+
+- `fix: ...` → patch release
+- `feat: ...` → minor release
+- `feat!: ...` or `BREAKING CHANGE:` footer → major release
+- `chore: ...`, `docs: ...`, `test: ...`, `refactor: ...`, `ci: ...` → no release
+
+Scopes are optional but helpful (e.g. `fix(rgb): ...`, `feat(palettes): ...`).
+
+## Pull requests
+
+- Open a PR against `main`. CI must be green before review.
+- Keep the diff focused. One logical change per PR.
+- Add or update tests for any behavior change. Coverage is tracked; reductions are scrutinized.
+- Update the README or JSDoc if you change a public API surface.
+- Merge strategy: merge-commits (preserves individual commit semantics for semantic-release).
+
+## Reporting issues
+
+- Bugs: [open an issue](https://github.com/simiancraft/chromonym/issues/new/choose).
+- Security: see [SECURITY.md](./SECURITY.md). **Do not** file public issues for vulnerabilities — use GitHub Security Advisories or email info@simiancraft.com.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant 2.1](./CODE_OF_CONDUCT.md). By participating, you agree to uphold it.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![CI](https://github.com/simiancraft/chromonym/actions/workflows/ci.yml/badge.svg)](https://github.com/simiancraft/chromonym/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/simiancraft/chromonym?logo=codecov)](https://codecov.io/github/simiancraft/chromonym)
 [![Bundle size](https://img.shields.io/badge/bundle-1.5--20%20kB%20gz-informational)](#what-you-actually-ship)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/simiancraft/chromonym/badge)](https://securityscorecards.dev/viewer/?uri=github.com/simiancraft/chromonym)
 
 <p align="center">
   <code>identify</code> &nbsp;•&nbsp; <code>resolve</code> &nbsp;•&nbsp; <code>convert</code>

--- a/src/conversions/rgb.ts
+++ b/src/conversions/rgb.ts
@@ -1,8 +1,11 @@
 import { clamp, requireFinite } from '../math/clamp.js';
 import type { Rgba, RgbaInput, RgbInput, RgbObject, RgbString } from '../types.js';
 
+// Alpha group split into two unambiguous alternatives to avoid polynomial
+// backtracking (CodeQL js/polynomial-redos) on malformed inputs like
+// `rgb(9,9,9,99...9`.
 const RGB_RE =
-  /^rgba?\s*\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*(?:,\s*(\d*\.?\d+)\s*)?\)$/i;
+  /^rgba?\s*\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*(?:,\s*(\d+(?:\.\d+)?|\.\d+)\s*)?\)$/i;
 
 function sanitizeChannel(n: unknown, label: string): number {
   return clamp(requireFinite(n, label), 0, 255);

--- a/src/conversions/rgb.ts
+++ b/src/conversions/rgb.ts
@@ -19,7 +19,8 @@ function sanitizeAlpha(n: unknown): number {
  * Normalize any RGB/RGBA input shape (string, tuple, or object) into
  * the canonical Rgba representation. Alpha defaults to 1 when absent.
  * Rejects non-finite numeric inputs; clamps r/g/b to [0,255] and a to [0,1].
- * Throws on malformed strings.
+ * Throws on malformed strings. String parsing is linear-time; no polynomial
+ * backtracking on pathological input.
  */
 export function rgbToRgba(input: RgbInput | RgbaInput): Rgba {
   if (Array.isArray(input)) {

--- a/src/conversions/rgb.ts
+++ b/src/conversions/rgb.ts
@@ -20,7 +20,12 @@ function sanitizeAlpha(n: unknown): number {
  * the canonical Rgba representation. Alpha defaults to 1 when absent.
  * Rejects non-finite numeric inputs; clamps r/g/b to [0,255] and a to [0,1].
  * Throws on malformed strings. String parsing is linear-time; no polynomial
- * backtracking on pathological input.
+ * backtracking on pathological input. Leading-dot alpha (e.g. `.5`) is
+ * accepted per the CSS Color spec.
+ *
+ * @example
+ * rgbToRgba('rgba(255, 0, 0, .5)');
+ * // => { r: 255, g: 0, b: 0, a: 0.5 }
  */
 export function rgbToRgba(input: RgbInput | RgbaInput): Rgba {
   if (Array.isArray(input)) {

--- a/test/conversions/rgb.test.ts
+++ b/test/conversions/rgb.test.ts
@@ -61,14 +61,21 @@ describe('rgbToRgba', () => {
       // @ts-expect-error runtime guard for invalid input
       expect(() => rgbToRgba('hsl(0, 100%, 50%)')).toThrow();
     });
-    // Regression for CodeQL js/polynomial-redos: a long digit run with no
-    // closing paren must fail fast, not backtrack exponentially.
-    it('rejects ReDoS-shaped input quickly', () => {
+    // Perf-regression canary for CodeQL js/polynomial-redos. Against a linear-time
+    // regex this runs in ~1ms; against a backtracking regex it balloons to seconds
+    // or hangs. The .toThrow() check alone cannot detect that regression — a
+    // regressed regex still eventually throws, just catastrophically slowly — so
+    // the wall-clock bound is the actual signal. 250ms gives ~250× headroom for
+    // CI noise (cold JIT, shared runner, coverage instrumentation) without
+    // weakening the check: any real ReDoS reappearance takes orders of magnitude
+    // longer than that. Doubles as a defense-in-depth check against injection of
+    // untrusted input into the rgb() parser (e.g. user-supplied CSS strings).
+    it('matches malformed input in linear time (ReDoS regression guard)', () => {
       const attack = `rgb(9,9,9,${'9'.repeat(50_000)}`;
       const start = performance.now();
       // @ts-expect-error runtime guard for invalid input
       expect(() => rgbToRgba(attack)).toThrow();
-      expect(performance.now() - start).toBeLessThan(100);
+      expect(performance.now() - start).toBeLessThan(250);
     });
   });
 });

--- a/test/conversions/rgb.test.ts
+++ b/test/conversions/rgb.test.ts
@@ -45,6 +45,14 @@ describe('rgbToRgba', () => {
         a: 0.75,
       });
     });
+    it('parses leading-dot alpha like ".5"', () => {
+      expect(rgbToRgba('rgba(255, 0, 0, .5)')).toEqual({
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 0.5,
+      });
+    });
     it('throws on malformed string', () => {
       // @ts-expect-error runtime guard for invalid input
       expect(() => rgbToRgba('rgb(abc)')).toThrow();
@@ -52,6 +60,15 @@ describe('rgbToRgba', () => {
     it('throws on wrong function name', () => {
       // @ts-expect-error runtime guard for invalid input
       expect(() => rgbToRgba('hsl(0, 100%, 50%)')).toThrow();
+    });
+    // Regression for CodeQL js/polynomial-redos: a long digit run with no
+    // closing paren must fail fast, not backtrack exponentially.
+    it('rejects ReDoS-shaped input quickly', () => {
+      const attack = `rgb(9,9,9,${'9'.repeat(50_000)}`;
+      const start = performance.now();
+      // @ts-expect-error runtime guard for invalid input
+      expect(() => rgbToRgba(attack)).toThrow();
+      expect(performance.now() - start).toBeLessThan(100);
     });
   });
 });


### PR DESCRIPTION
Repo-hygiene pass. Covers security (ReDoS), CI permissions, test clarity, funding, supply-chain transparency via OpenSSF Scorecard, and the community-health files GitHub's Community Standards checklist looks for. These files are intended as a baseline future Simiancraft projects can copy.

Merge-commit flow preserves individual commits; `semantic-release` will cut a patch from the two `fix:` commits. The four `chore:`/`docs:` commits are release-neutral.

## Security

- **`fix(security):` harden `rgb()` parser against polynomial ReDoS** (`c5f5bbd`); replaces the backtracking-prone alternation in `RGB_RE` with a linear-time equivalent. Side effect: `.5`-style leading-dot alpha values now parse (previously ambiguous).

## CI hygiene

- **`fix(ci):` set least-privilege `GITHUB_TOKEN` permissions on CI workflow** (`946d322`); workflow-root `permissions: contents: read` with a scoped write block on the `release` job only. Combined with the pre-existing explicit blocks on `deploy-demo.yml` and `link-check.yml`, all workflows now declare explicit permissions. Advances OpenSSF Scorecard `Token-Permissions`.

## Test clarity

- **`chore(rgb):` rename ReDoS-guard test and document its perf-regression intent** (`9543748`); the test's actual invariant is "matches in linear time." The `.toThrow()` check cannot distinguish a fixed regex from a backtracking one (both throw eventually), so the wall-clock bound is the real signal. Widened 100ms to 250ms for CI-noise headroom. Adds a JSDoc line on `rgbToRgba` noting the linear-time guarantee.

## Funding

- **`docs:` add `.github/FUNDING.yml` pointing to Ko-fi** (`2c24b09`); enables the Sponsor button on the repo sidebar.

## Community-health bootstrap

- **`chore:` bootstrap community-health files** (`76d6e13`); adds:
  - `CODE_OF_CONDUCT.md` (canonical Contributor Covenant 2.1, contact `info@simiancraft.com`)
  - `CONTRIBUTING.md` (real `bun` workflow plus Conventional Commits / semantic-release guidance)
  - `.github/ISSUE_TEMPLATE/bug_report.yml` (structured form requiring version, runtime, minimal reproduction)
  - `.github/ISSUE_TEMPLATE/feature_request.yml` (problem-first form with scope-fit checkbox)
  - `.github/ISSUE_TEMPLATE/config.yml` (blank issues disabled; security reports routed to Advisories)
  - `.github/PULL_REQUEST_TEMPLATE.md` (summary, changes, testing, checklist)
  - `CODEOWNERS` (`* @the-simian`)

## Supply-chain transparency

- **`chore:` add OpenSSF Scorecard workflow and README badge** (`d8aee3c`); runs weekly, on every push to `main`, and on `branch_protection_rule` events. Writes SARIF to the Security tab and publishes to the public `scorecard.dev` dashboard, which powers the README badge. All action references SHA-pinned.

## Repo settings (changed via API, not in diff)

- **Dependabot security updates**: enabled (was disabled). This is separate from `.github/dependabot.yml`; it auto-opens PRs against GHSA-reported vulnerabilities in dependencies, independent of the weekly schedule already configured for GitHub Actions updates.
- **Vulnerability alerts**: enabled (prerequisite for the above).

## Pre-existing protections (verified, documented here for the record)

- Branch protection on `main` is enforced via two **rulesets** (`main` + `main-protection`), not classic branch protection; the older `/branches/main/protection` endpoint returns 404 but rulesets are active. `main-protection` requires the `Lint, Typecheck, Test` status check to pass and blocks deletion plus non-fast-forward pushes, with a single bypass actor (the `semantic-release` GitHub App).

## CI

All green on previous commits: Lint/Typecheck/Test (471 tests, 100% coverage held), CodeQL (js-ts + actions), codecov patch + project. New Scorecard workflow will first execute on merge to `main`.