### PR TITLE
ci: pin scorecard-action to commit SHA, not tag object SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Context

The first Scorecard run on `main` (triggered by the PR #17 merge) **failed the upload step** with HTTP 400 from the OSSF webapp:

```
workflow verification failed: imposter commit:
99c09fe975337306107572b4fdf4db224cf8e2f2 does not belong to ossf/scorecard-action
```

The scan itself ran correctly; the score was **7.2/10** (SAST 10/10, Token-Permissions 10/10, Pinned-Dependencies 10/10, Security-Policy 10/10, Dangerous-Workflow 10/10, License 10/10, Vulnerabilities 10/10, Binary-Artifacts 10/10). Only the upload to the public dashboard failed, so the README badge cannot populate until this is fixed.

## Root cause

Scorecard's webapp does server-side verification that the SHA you pinned `ossf/scorecard-action` at is a commit on that repository. I pinned the **tag object SHA** (`99c09fe...`) returned by `GET /repos/ossf/scorecard-action/git/refs/tags/v2.4.3`; the webapp expects the **commit SHA** the tag points to.

## Fix

Replace the pin in `.github/workflows/scorecard.yml`:

- Before: `ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3` (tag object)
- After:  `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3` (commit)

Both SHAs resolve to `v2.4.3`; the action itself is unchanged.

## Scope

Only the `scorecard-action` pin is changed. Other pre-existing action pins in this repo (e.g. `actions/checkout@de0fac2e...`) also use tag-object SHAs rather than commit SHAs; those work fine because regular GitHub Actions do not do their own self-verification. Deliberately leaving them alone to keep this PR minimal. A repo-wide SHA-pin sweep would be a separate follow-up.

## Commit type

`ci:` (not `fix:`); this is an internal CI wiring correction, not a user-facing fix. Semantic-release will not cut a release from this commit.

## Verification plan

- [ ] CI green on this PR
- [ ] After merge, manually trigger the Scorecard workflow on `main` (or wait for the Saturday cron)
- [ ] Confirm the upload step completes with HTTP 200
- [ ] Confirm the README badge populates (currently "unknown")