### PR TITLE
feat: export VERSION constant; require Node >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,6 @@
     "provenance": true
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
-// Public API barrel — explicit named re-exports only (tree-shake friendly).
+// Public API barrel; explicit named re-exports only (tree-shake friendly).
 // No default export; no side effects at module scope.
+
+import pkg from '../package.json' with { type: 'json' };
+
+export const VERSION: string = pkg.version;
 
 export { hexToRgba, rgbaToHex } from './conversions/hex.js';
 export { hslToRgba, rgbaToHsl } from './conversions/hsl.js';


### PR DESCRIPTION
## What changed

- `src/index.ts`: read `pkg.version` via JSON import attribute (`import pkg from '../package.json' with { type: 'json' }`); add `export const VERSION: string`.
- `package.json`: bump `engines.node` from `>=20` to `>=22`.

## Why the engine bump

Import attributes (`with { type: "json" }`) are stable from Node 22 onward; Node 20 only supported the deprecated `assert` form. Node 20 reached EOL in April 2026, so consumers on supported Node versions are unaffected. Node 22 remains active LTS through October 2026.

## Verification

- `bun run typecheck`: clean
- `bun run lint`: clean
- `bun test`: 472 / 472 pass
- `bun run build`: emits `import pkg from '../package.json' with { type: 'json' }` verbatim
- `bun run check:package` (publint + attw): clean
- Runtime resolution from `dist/index.js`: returns `3.3.1`

## Release posture

Scoped to be the only substantive change in the next published release.