### PR TITLE
feat(palettes): add pokemon, werner, tailwind, and ral

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -313,6 +313,27 @@ terms allowing free reuse with attribution. If the upstream author
 objects to Chromonym's inclusion of the list, open an issue and we
 will revisit.
 
+## RAL®
+
+**RAL®** is a registered trademark of **RAL gGmbH** (Bonn, Germany).
+Chromonym is **not affiliated with, endorsed by, licensed by, or
+certified by RAL gGmbH**.
+
+The `ral` palette ships the RAL Classic set (216 entries spanning
+RAL 1000 through RAL 9023) as a nominative reference to publicly
+identified RAL color codes. sRGB hex values are derived from the
+**MIT-licensed `JohannesVoigt/ral-color-converter` dataset**
+(<https://github.com/JohannesVoigt/ral-color-converter>), which ships
+the Classic set with multi-language names, CMYK, and LRV companions.
+
+The values are community-cited approximations and will not match a
+licensed RAL reference (physical RAL K7 fan deck, RAL Digital, or the
+RAL Connect SDK) exactly. They are intended for on-screen reference,
+nearest-name identification, and general tooling — **not for paint
+formulation, coating specification, or industrial color matching**.
+For RAL-certified values, consult RAL directly:
+<https://www.ral-farben.de/en/>.
+
 ## Tailwind CSS
 
 **Tailwind CSS** is licensed under the **MIT License**, © Tailwind Labs,

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -313,6 +313,21 @@ terms allowing free reuse with attribution. If the upstream author
 objects to Chromonym's inclusion of the list, open an issue and we
 will revisit.
 
+## Pokémon™
+
+**Pokémon™** is a trademark of **Nintendo, Game Freak, and The Pokémon
+Company**. Chromonym is **not affiliated with, endorsed by, licensed
+by, or certified by** any of those entities.
+
+The `pokemon` palette ships sRGB approximations of the 18 canonical
+type-badge colors (Normal through Fairy) as documented on
+[Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Type), which itself
+sources from in-game asset extraction. The type names are used as
+**nominative references** to publicly identified Pokémon type symbols;
+no endorsement, asset-license, or trademark claim is implied. Hex
+values are community-cited approximations, not extracted production
+assets.
+
 ## Bauhaus Modern (demo site typeface)
 
 The demo site at <https://simiancraft.github.io/chromonym/> embeds

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -313,6 +313,24 @@ terms allowing free reuse with attribution. If the upstream author
 objects to Chromonym's inclusion of the list, open an issue and we
 will revisit.
 
+## Werner's Nomenclature of Colours
+
+The `werner` palette ships the 110 named pigments from **Werner's
+Nomenclature of Colours** (1821), Patrick Syme's adaptation of Abraham
+Werner's mineralogical color system. The original 1821 text is public
+domain.
+
+The sRGB hex values were sampled from physical chip swatches by
+**Nicholas Rougeux** and published at
+[www.c82.net/werner/](https://www.c82.net/werner/) under
+**CC BY 4.0** (Creative Commons Attribution 4.0 International). This
+palette redistributes those values with attribution under the same
+license. If you redistribute the `werner` palette downstream, preserve
+this attribution.
+
+The 1821 names are used as nominative references to publicly identified
+historical pigments; no endorsement is implied.
+
 ## Pokémon™
 
 **Pokémon™** is a trademark of **Nintendo, Game Freak, and The Pokémon

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -313,6 +313,27 @@ terms allowing free reuse with attribution. If the upstream author
 objects to Chromonym's inclusion of the list, open an issue and we
 will revisit.
 
+## Tailwind CSS
+
+**Tailwind CSS** is licensed under the **MIT License**, © Tailwind Labs,
+Inc. The `tailwind` palette ships the default theme of **Tailwind CSS
+v4.0** (22 color families × 11 shades = 242 entries).
+
+The v4.0 default theme is defined in OKLCH (Tailwind v4 shipped its
+first OKLCH-native theme; earlier versions used hex). This palette
+converts those OKLCH values to sRGB hex via Björn Ottosson's reference
+OKLAB→linear sRGB matrix and the standard IEC 61966-2-1 sRGB transfer
+function. Out-of-sRGB-gamut OKLCH values (notably some saturated
+500-600 shades) are clamped to [0, 1] before encoding; the visible
+result in a wide-gamut browser will differ from the sRGB hex shipped
+here.
+
+Tailwind v4.2+ adds families (mauve, olive, mist, taupe) that are
+intentionally not included; this palette is pinned to v4.0 per the
+shipping intent. A future palette bump may track later v4.x defaults.
+
+Tailwind documentation: <https://tailwindcss.com/docs/colors>.
+
 ## Werner's Nomenclature of Colours
 
 The `werner` palette ships the 110 named pigments from **Werner's

--- a/demo/src/components/PaletteGrid.tsx
+++ b/demo/src/components/PaletteGrid.tsx
@@ -12,6 +12,7 @@ import {
   ncs,
   ntc,
   pantone,
+  pokemon,
   resene,
   web,
   x11,
@@ -39,6 +40,7 @@ export const PALETTES = {
   nbs,
   resene,
   ncs,
+  pokemon,
 } as const;
 export type PaletteKey = keyof typeof PALETTES;
 
@@ -55,6 +57,7 @@ export const PALETTE_LABELS: Record<PaletteKey, string> = {
   nbs: 'NBS',
   resene: 'Resene',
   ncs: 'NCS',
+  pokemon: 'Pokémon',
 };
 
 // Short demo-side descriptions surfaced in the palette-picker panel. Kept in
@@ -73,6 +76,7 @@ export const PALETTE_DESCRIPTIONS: Record<PaletteKey, string> = {
   nbs: "Alternate NBS digitization: same 1955 vocabulary as isccNbs, different sRGB values matching the physical chip book.",
   resene: "Resene Paints (New Zealand) catalog. 1378 named coatings with te reo Māori and NZ place-names.",
   ncs: "Natural Colour System (Sweden). Perceptual codes like '2030-R80B' describing blackness, chromaticness, and hue.",
+  pokemon: 'The 18 canonical Pokémon type colors (Normal through Fairy). Tiny, iconic, useful as a chart theme. Nominative reference, not an official asset set.',
 };
 
 export const PALETTE_KEYS = [
@@ -88,6 +92,7 @@ export const PALETTE_KEYS = [
   'nbs',
   'resene',
   'ncs',
+  'pokemon',
 ] as const satisfies readonly PaletteKey[];
 
 interface PaletteGridProps {

--- a/demo/src/components/PaletteGrid.tsx
+++ b/demo/src/components/PaletteGrid.tsx
@@ -14,6 +14,7 @@ import {
   pantone,
   pokemon,
   resene,
+  tailwind,
   web,
   werner,
   x11,
@@ -43,6 +44,7 @@ export const PALETTES = {
   ncs,
   pokemon,
   werner,
+  tailwind,
 } as const;
 export type PaletteKey = keyof typeof PALETTES;
 
@@ -61,6 +63,7 @@ export const PALETTE_LABELS: Record<PaletteKey, string> = {
   ncs: 'NCS',
   pokemon: 'Pokémon',
   werner: "Werner's (1821)",
+  tailwind: 'Tailwind',
 };
 
 // Short demo-side descriptions surfaced in the palette-picker panel. Kept in
@@ -81,6 +84,7 @@ export const PALETTE_DESCRIPTIONS: Record<PaletteKey, string> = {
   ncs: "Natural Colour System (Sweden). Perceptual codes like '2030-R80B' describing blackness, chromaticness, and hue.",
   pokemon: 'The 18 canonical Pokémon type colors (Normal through Fairy). Tiny, iconic, useful as a chart theme. Nominative reference, not an official asset set.',
   werner: "Werner's Nomenclature of Colours (1821), the historical pigment reference Patrick Syme adapted from Abraham Werner and Darwin carried on the Beagle. 110 names with natural-history exemplars; hex values via Rougeux's CC-BY digitization.",
+  tailwind: "Tailwind CSS default theme (v4.0). 22 hue families × 11 shades = 242 entries with keys matching the Tailwind class suffix ('slate-500', 'rose-950'). sRGB values converted from v4.0's OKLCH spec.",
 };
 
 export const PALETTE_KEYS = [
@@ -98,6 +102,7 @@ export const PALETTE_KEYS = [
   'ncs',
   'pokemon',
   'werner',
+  'tailwind',
 ] as const satisfies readonly PaletteKey[];
 
 interface PaletteGridProps {

--- a/demo/src/components/PaletteGrid.tsx
+++ b/demo/src/components/PaletteGrid.tsx
@@ -13,6 +13,7 @@ import {
   ntc,
   pantone,
   pokemon,
+  ral,
   resene,
   tailwind,
   web,
@@ -45,6 +46,7 @@ export const PALETTES = {
   pokemon,
   werner,
   tailwind,
+  ral,
 } as const;
 export type PaletteKey = keyof typeof PALETTES;
 
@@ -64,6 +66,7 @@ export const PALETTE_LABELS: Record<PaletteKey, string> = {
   pokemon: 'Pokémon',
   werner: "Werner's (1821)",
   tailwind: 'Tailwind',
+  ral: 'RAL Classic',
 };
 
 // Short demo-side descriptions surfaced in the palette-picker panel. Kept in
@@ -85,6 +88,7 @@ export const PALETTE_DESCRIPTIONS: Record<PaletteKey, string> = {
   pokemon: 'The 18 canonical Pokémon type colors (Normal through Fairy). Tiny, iconic, useful as a chart theme. Nominative reference, not an official asset set.',
   werner: "Werner's Nomenclature of Colours (1821), the historical pigment reference Patrick Syme adapted from Abraham Werner and Darwin carried on the Beagle. 110 names with natural-history exemplars; hex values via Rougeux's CC-BY digitization.",
   tailwind: "Tailwind CSS default theme (v4.0). 22 hue families × 11 shades = 242 entries with keys matching the Tailwind class suffix ('slate-500', 'rose-950'). sRGB values converted from v4.0's OKLCH spec.",
+  ral: "RAL Classic (RAL gGmbH, Bonn). 216 European industrial / architectural coatings keyed by RAL code ('RAL 1003', 'RAL 9011'). Pantone analog for European product, paint, and signage work; nominative reference, not a licensed RAL product.",
 };
 
 export const PALETTE_KEYS = [
@@ -103,6 +107,7 @@ export const PALETTE_KEYS = [
   'pokemon',
   'werner',
   'tailwind',
+  'ral',
 ] as const satisfies readonly PaletteKey[];
 
 interface PaletteGridProps {

--- a/demo/src/components/PaletteGrid.tsx
+++ b/demo/src/components/PaletteGrid.tsx
@@ -15,6 +15,7 @@ import {
   pokemon,
   resene,
   web,
+  werner,
   x11,
   xkcd,
 } from 'chromonym';
@@ -41,6 +42,7 @@ export const PALETTES = {
   resene,
   ncs,
   pokemon,
+  werner,
 } as const;
 export type PaletteKey = keyof typeof PALETTES;
 
@@ -58,6 +60,7 @@ export const PALETTE_LABELS: Record<PaletteKey, string> = {
   resene: 'Resene',
   ncs: 'NCS',
   pokemon: 'Pokémon',
+  werner: "Werner's (1821)",
 };
 
 // Short demo-side descriptions surfaced in the palette-picker panel. Kept in
@@ -77,6 +80,7 @@ export const PALETTE_DESCRIPTIONS: Record<PaletteKey, string> = {
   resene: "Resene Paints (New Zealand) catalog. 1378 named coatings with te reo Māori and NZ place-names.",
   ncs: "Natural Colour System (Sweden). Perceptual codes like '2030-R80B' describing blackness, chromaticness, and hue.",
   pokemon: 'The 18 canonical Pokémon type colors (Normal through Fairy). Tiny, iconic, useful as a chart theme. Nominative reference, not an official asset set.',
+  werner: "Werner's Nomenclature of Colours (1821), the historical pigment reference Patrick Syme adapted from Abraham Werner and Darwin carried on the Beagle. 110 names with natural-history exemplars; hex values via Rougeux's CC-BY digitization.",
 };
 
 export const PALETTE_KEYS = [
@@ -93,6 +97,7 @@ export const PALETTE_KEYS = [
   'resene',
   'ncs',
   'pokemon',
+  'werner',
 ] as const satisfies readonly PaletteKey[];
 
 interface PaletteGridProps {

--- a/demo/src/components/PaletteTiles.tsx
+++ b/demo/src/components/PaletteTiles.tsx
@@ -61,6 +61,11 @@ const TILE_META: Record<PaletteKey, { tone: string; ink: string }> = {
   // the NCS system grew out of. Pulls toward steel, distinct from
   // pantone's saturated blue.
   ncs: { tone: '#3e5a78', ink: 'var(--bh-cream)' },
+  // Pokémon: official Fire-type red-orange. The 18-color palette is
+  // unmistakably pop-cultural; the tile leans into that with one of
+  // its own canonical hues instead of trying to blend with the
+  // Bauhaus-restrained tones above.
+  pokemon: { tone: '#ee8130', ink: 'var(--bh-cream)' },
 };
 
 const ORDER: PaletteKey[] = [
@@ -76,6 +81,7 @@ const ORDER: PaletteKey[] = [
   'nbs',
   'resene',
   'ncs',
+  'pokemon',
 ];
 
 // Indicator square — same scale family as the sample swatches (h-3 ≈ 12px).

--- a/demo/src/components/PaletteTiles.tsx
+++ b/demo/src/components/PaletteTiles.tsx
@@ -71,6 +71,11 @@ const TILE_META: Record<PaletteKey, { tone: string; ink: string }> = {
   // would have pointed at on his card. Tile color signals the
   // historical-pigment register, distinct from web/x11 modern blues.
   werner: { tone: '#7994b5', ink: 'var(--bh-ink)' },
+  // Tailwind: sky-500 (#00a6f4 in v4.0 / our converted spec) is the
+  // most-recognized Tailwind hue and lives in the brand's own
+  // marketing material. Reads instantly as "the Tailwind palette"
+  // to anyone who's used the framework.
+  tailwind: { tone: '#00a6f4', ink: 'var(--bh-cream)' },
 };
 
 const ORDER: PaletteKey[] = [
@@ -88,6 +93,7 @@ const ORDER: PaletteKey[] = [
   'ncs',
   'pokemon',
   'werner',
+  'tailwind',
 ];
 
 // Indicator square — same scale family as the sample swatches (h-3 ≈ 12px).

--- a/demo/src/components/PaletteTiles.tsx
+++ b/demo/src/components/PaletteTiles.tsx
@@ -66,6 +66,11 @@ const TILE_META: Record<PaletteKey, { tone: string; ink: string }> = {
   // its own canonical hues instead of trying to blend with the
   // Bauhaus-restrained tones above.
   pokemon: { tone: '#ee8130', ink: 'var(--bh-cream)' },
+  // Werner: Berlin Blue (#7994b5) is the palette's central
+  // characteristic blue — Werner's own "pure" blue, the one Darwin
+  // would have pointed at on his card. Tile color signals the
+  // historical-pigment register, distinct from web/x11 modern blues.
+  werner: { tone: '#7994b5', ink: 'var(--bh-ink)' },
 };
 
 const ORDER: PaletteKey[] = [
@@ -82,6 +87,7 @@ const ORDER: PaletteKey[] = [
   'resene',
   'ncs',
   'pokemon',
+  'werner',
 ];
 
 // Indicator square — same scale family as the sample swatches (h-3 ≈ 12px).

--- a/demo/src/components/PaletteTiles.tsx
+++ b/demo/src/components/PaletteTiles.tsx
@@ -76,6 +76,11 @@ const TILE_META: Record<PaletteKey, { tone: string; ink: string }> = {
   // marketing material. Reads instantly as "the Tailwind palette"
   // to anyone who's used the framework.
   tailwind: { tone: '#00a6f4', ink: 'var(--bh-cream)' },
+  // RAL: RAL 3020 Traffic red (#bb1f11), the most recognizable
+  // industrial-signage red in the catalogue (it's literally what
+  // European traffic signs use). Reads as "European industrial
+  // standard" without being indistinguishable from web's bh-red.
+  ral: { tone: '#bb1f11', ink: 'var(--bh-cream)' },
 };
 
 const ORDER: PaletteKey[] = [
@@ -94,6 +99,7 @@ const ORDER: PaletteKey[] = [
   'pokemon',
   'werner',
   'tailwind',
+  'ral',
 ];
 
 // Indicator square — same scale family as the sample swatches (h-3 ≈ 12px).

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
       "import": "./dist/palettes/pokemon.js",
       "default": "./dist/palettes/pokemon.js"
     },
+    "./ral": {
+      "types": "./dist/palettes/ral.d.ts",
+      "import": "./dist/palettes/ral.js",
+      "default": "./dist/palettes/ral.js"
+    },
     "./resene": {
       "types": "./dist/palettes/resene.d.ts",
       "import": "./dist/palettes/resene.js",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/palettes/resene.js",
       "default": "./dist/palettes/resene.js"
     },
+    "./tailwind": {
+      "types": "./dist/palettes/tailwind.d.ts",
+      "import": "./dist/palettes/tailwind.js",
+      "default": "./dist/palettes/tailwind.js"
+    },
     "./crayola": {
       "types": "./dist/palettes/crayola.d.ts",
       "import": "./dist/palettes/crayola.js",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
       "import": "./dist/palettes/ntc.js",
       "default": "./dist/palettes/ntc.js"
     },
+    "./werner": {
+      "types": "./dist/palettes/werner.d.ts",
+      "import": "./dist/palettes/werner.js",
+      "default": "./dist/palettes/werner.js"
+    },
     "./xkcd": {
       "types": "./dist/palettes/xkcd.d.ts",
       "import": "./dist/palettes/xkcd.js",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
       "import": "./dist/palettes/pantone.js",
       "default": "./dist/palettes/pantone.js"
     },
+    "./pokemon": {
+      "types": "./dist/palettes/pokemon.d.ts",
+      "import": "./dist/palettes/pokemon.js",
+      "default": "./dist/palettes/pokemon.js"
+    },
     "./resene": {
       "types": "./dist/palettes/resene.d.ts",
       "import": "./dist/palettes/resene.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export { type PantoneColorName, pantone } from './palettes/pantone.js';
 export { type PokemonColorName, pokemon } from './palettes/pokemon.js';
 export { type ReseneColorName, resene } from './palettes/resene.js';
 export { type WebColorName, web } from './palettes/web.js';
+export { type WernerColorName, werner } from './palettes/werner.js';
 export { type X11ColorName, x11 } from './palettes/x11.js';
 export { type XkcdColorName, xkcd } from './palettes/xkcd.js';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export { type NcsColorName, ncs } from './palettes/ncs.js';
 export { type NtcColorName, ntc } from './palettes/ntc.js';
 export { type PantoneColorName, pantone } from './palettes/pantone.js';
 export { type PokemonColorName, pokemon } from './palettes/pokemon.js';
+export { type RalColorName, ral } from './palettes/ral.js';
 export { type ReseneColorName, resene } from './palettes/resene.js';
 export { type TailwindColorName, tailwind } from './palettes/tailwind.js';
 export { type WebColorName, web } from './palettes/web.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export { type NbsColorName, nbs } from './palettes/nbs.js';
 export { type NcsColorName, ncs } from './palettes/ncs.js';
 export { type NtcColorName, ntc } from './palettes/ntc.js';
 export { type PantoneColorName, pantone } from './palettes/pantone.js';
+export { type PokemonColorName, pokemon } from './palettes/pokemon.js';
 export { type ReseneColorName, resene } from './palettes/resene.js';
 export { type WebColorName, web } from './palettes/web.js';
 export { type X11ColorName, x11 } from './palettes/x11.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export { type NtcColorName, ntc } from './palettes/ntc.js';
 export { type PantoneColorName, pantone } from './palettes/pantone.js';
 export { type PokemonColorName, pokemon } from './palettes/pokemon.js';
 export { type ReseneColorName, resene } from './palettes/resene.js';
+export { type TailwindColorName, tailwind } from './palettes/tailwind.js';
 export { type WebColorName, web } from './palettes/web.js';
 export { type WernerColorName, werner } from './palettes/werner.js';
 export { type X11ColorName, x11 } from './palettes/x11.js';

--- a/src/palettes/pokemon.ts
+++ b/src/palettes/pokemon.ts
@@ -1,0 +1,70 @@
+import type { Palette } from '../types.js';
+import { standardNormalize } from './normalize.js';
+
+/**
+ * Pokémon type colors — the 18 canonical type symbols as displayed on
+ * type badges in modern Pokémon media.
+ *
+ * Keys are Title Case singular ('Fire', 'Water', 'Grass'), matching the
+ * in-game spelling. `standardNormalize` strips case and punctuation, so
+ * `resolve('fire')`, `resolve('FIRE')`, and `resolve('Fire')` all hit
+ * the same entry.
+ *
+ * sRGB values are community-cited approximations of the type-badge
+ * colors documented on Bulbapedia
+ * (https://bulbapedia.bulbagarden.net/wiki/Type), which itself sources
+ * from in-game asset extraction. Pokémon names and the type framework
+ * are trademarks of Nintendo, Game Freak, and The Pokémon Company; this
+ * palette is a nominative reference, not an official asset set. See
+ * NOTICE.md.
+ *
+ * Default metric: `deltaE76`. The set is tiny (18 entries) and the
+ * inter-color distances are large enough that any sensible metric
+ * picks the same neighbor; deltaE76 is the cheapest.
+ */
+const pokemonColors = {
+  // --- Gen 1 (RGBY) ---
+  Normal: '#a8a77a',
+  Fighting: '#c22e28',
+  Flying: '#a98ff3',
+  Poison: '#a33ea1',
+  Ground: '#e2bf65',
+  Rock: '#b6a136',
+  Bug: '#a6b91a',
+  Ghost: '#735797',
+  Fire: '#ee8130',
+  Water: '#6390f0',
+  Grass: '#7ac74c',
+  Electric: '#f7d02c',
+  Psychic: '#f95587',
+  Ice: '#96d9d6',
+  Dragon: '#6f35fc',
+
+  // --- Gen 2 (GSC) ---
+  Dark: '#705746',
+  Steel: '#b7b7ce',
+
+  // --- Gen 6 (XY) ---
+  Fairy: '#d685ad',
+} as const;
+
+export type PokemonColorName = keyof typeof pokemonColors;
+
+/**
+ * The 18 Pokémon type colors as a `Palette<PokemonColorName>`.
+ *
+ * Keys are Title Case ('Fire', 'Water'); standard normalizer accepts
+ * any case + punctuation variant. Default metric is `'deltaE76'`: the
+ * set is small enough that metric choice is academic.
+ *
+ * @example
+ * identify('#ee8130', { palette: pokemon });          // 'Fire'
+ * resolve('water', { palette: pokemon });             // '#6390f0'
+ * pokemon.colors.Dragon;                              // '#6f35fc'
+ */
+export const pokemon = {
+  name: 'pokemon',
+  colors: pokemonColors,
+  normalize: standardNormalize,
+  defaultMetric: 'deltaE76',
+} as const satisfies Palette<PokemonColorName>;

--- a/src/palettes/ral.ts
+++ b/src/palettes/ral.ts
@@ -1,0 +1,275 @@
+import type { Palette } from '../types.js';
+import { standardNormalize } from './normalize.js';
+
+/**
+ * RAL Classic — the European industrial color standard published by
+ * RAL gGmbH (Bonn), used across paint, coatings, architecture, signage,
+ * and manufacturing. Originated in 1927 with 40 colors; this palette
+ * ships the modern 216-entry Classic set spanning ten groups (Yellows
+ * through Whites/Blacks).
+ *
+ * Keys are the RAL code verbatim ('RAL 1000', 'RAL 9023'). The English
+ * color name is preserved as an inline source comment for skimmers but
+ * is not part of the key — lookups go through the code, mirroring how
+ * Pantone is keyed ('185 C') rather than by the color's name.
+ * `standardNormalize` strips the space, so `resolve('ral1000')`,
+ * `resolve('RAL 1000')`, and `resolve('Ral-1000')` all hit the same entry.
+ *
+ * sRGB values are from the MIT-licensed
+ * github.com/JohannesVoigt/ral-color-converter dataset, which ships
+ * the Classic set with multi-language names and CMYK / LRV companions.
+ * **RAL®** is a registered trademark of **RAL gGmbH**; this palette
+ * is a nominative reference, not a licensed RAL product. See NOTICE.md.
+ *
+ * Default metric: `deltaE2000`. RAL coatings cluster densely in some
+ * regions (the 7000 greys especially have 38 closely-spaced entries
+ * across the achromatic axis); CIEDE2000's hue/chroma compensation
+ * picks better neighbors than the cheaper deltaE76.
+ */
+const ralColors = {
+  // --- Yellows (RAL 1000-RAL 1037; 30 entries) ---
+  'RAL 1000': '#cdba88', // Green beige
+  'RAL 1001': '#d0b084', // Beige
+  'RAL 1002': '#d2aa6d', // Sand yellow
+  'RAL 1003': '#f9a900', // Signal yellow
+  'RAL 1004': '#e49e00', // Golden yellow
+  'RAL 1005': '#cb8f00', // Honey yellow
+  'RAL 1006': '#e19000', // Maize yellow
+  'RAL 1007': '#e88c00', // Daffodil yellow
+  'RAL 1011': '#af8050', // Brown beige
+  'RAL 1012': '#ddaf28', // Lemon yellow
+  'RAL 1013': '#e3d9c7', // Oyster white
+  'RAL 1014': '#ddc49b', // Ivory
+  'RAL 1015': '#e6d2b5', // Light ivory
+  'RAL 1016': '#f1dd39', // Sulfur yellow
+  'RAL 1017': '#f6a951', // Saffron yellow
+  'RAL 1018': '#faca31', // Zinc yellow
+  'RAL 1019': '#a48f7a', // Grey beige
+  'RAL 1020': '#a08f65', // Olive yellow
+  'RAL 1021': '#f6b600', // Colza yellow
+  'RAL 1023': '#f7b500', // Traffic yellow
+  'RAL 1024': '#ba8f4c', // Ochre yellow
+  'RAL 1026': '#ffff00', // Luminous yellow
+  'RAL 1027': '#a77f0f', // Curry
+  'RAL 1028': '#ff9c00', // Melon yellow
+  'RAL 1032': '#e2a300', // Broom yellow
+  'RAL 1033': '#f99a1d', // Dahlia yellow
+  'RAL 1034': '#eb9c52', // Pastel yellow
+  'RAL 1035': '#8f8370', // Pearl beige
+  'RAL 1036': '#806440', // Pearl gold
+  'RAL 1037': '#f09200', // Sun yellow
+  // --- Oranges (RAL 2000-RAL 2017; 14 entries) ---
+  'RAL 2000': '#da6e00', // Yellow orange
+  'RAL 2001': '#ba481c', // Red orange
+  'RAL 2002': '#bf3922', // Vermilion
+  'RAL 2003': '#f67829', // Pastel orange
+  'RAL 2004': '#e25304', // Pure orange
+  'RAL 2005': '#ff4d08', // Luminous orange
+  'RAL 2007': '#ffb200', // Luminous bright orange
+  'RAL 2008': '#ec6b22', // Bright red orange
+  'RAL 2009': '#de5308', // Traffic orange
+  'RAL 2010': '#d05d29', // Signal orange
+  'RAL 2011': '#e26e0f', // Deep orange
+  'RAL 2012': '#d5654e', // Salmon orange
+  'RAL 2013': '#923e25', // Pearl orange
+  'RAL 2017': '#fc5500', // RAL orange
+  // --- Reds (RAL 3000-RAL 3033; 25 entries) ---
+  'RAL 3000': '#a72920', // Flame red
+  'RAL 3001': '#9b2423', // Signal red
+  'RAL 3002': '#9b2321', // Carmine red
+  'RAL 3003': '#861a22', // Ruby red
+  'RAL 3004': '#6b1c23', // Purple red
+  'RAL 3005': '#59191f', // Wine red
+  'RAL 3007': '#3e2022', // Black red
+  'RAL 3009': '#6d342d', // Oxide red
+  'RAL 3011': '#782423', // Brown red
+  'RAL 3012': '#c5856d', // Beige red
+  'RAL 3013': '#972e25', // Tomato red
+  'RAL 3014': '#cb7375', // Antique pink
+  'RAL 3015': '#d8a0a6', // Light pink
+  'RAL 3016': '#a63d30', // Coral red
+  'RAL 3017': '#ca555d', // Rose
+  'RAL 3018': '#c63f4a', // Strawberry red
+  'RAL 3020': '#bb1f11', // Traffic red
+  'RAL 3022': '#cf6955', // Salmon pink
+  'RAL 3024': '#ff2d21', // Luminous red
+  'RAL 3026': '#ff2a1c', // Luminous bright red
+  'RAL 3027': '#ab273c', // Raspberry red
+  'RAL 3028': '#cc2c24', // Pure red
+  'RAL 3031': '#a63437', // Orient red
+  'RAL 3032': '#701d24', // Pearl ruby red
+  'RAL 3033': '#a53a2e', // Pearl pink
+  // --- Violets (RAL 4001-RAL 4012; 12 entries) ---
+  'RAL 4001': '#816183', // Red lilac
+  'RAL 4002': '#8d3c4b', // Red violet
+  'RAL 4003': '#c4618c', // Heather violet
+  'RAL 4004': '#651e38', // Claret violet
+  'RAL 4005': '#76689a', // Blue lilac
+  'RAL 4006': '#903373', // Traffic purple
+  'RAL 4007': '#47243c', // Purple violet
+  'RAL 4008': '#844c82', // Signal violet
+  'RAL 4009': '#9d8692', // Pastel violet
+  'RAL 4010': '#bb4077', // Telemagenta
+  'RAL 4011': '#6e6387', // Pearl violet
+  'RAL 4012': '#6a6b7f', // Pearl blackberry
+  // --- Blues (RAL 5000-RAL 5026; 25 entries) ---
+  'RAL 5000': '#304f6e', // Violet blue
+  'RAL 5001': '#0e4c64', // Green blue
+  'RAL 5002': '#00387a', // Ultramarine blue
+  'RAL 5003': '#1f3855', // Sapphire blue
+  'RAL 5004': '#191e28', // Black blue
+  'RAL 5005': '#005387', // Signal blue
+  'RAL 5007': '#376b8c', // Brillant blue
+  'RAL 5008': '#2b3a44', // Grey blue
+  'RAL 5009': '#215f78', // Azure blue
+  'RAL 5010': '#004f7c', // Gentian blue
+  'RAL 5011': '#1a2b3c', // Steel blue
+  'RAL 5012': '#0089b6', // Light blue
+  'RAL 5013': '#193153', // Cobalt blue
+  'RAL 5014': '#637d96', // Pigeon blue
+  'RAL 5015': '#007caf', // Sky blue
+  'RAL 5017': '#005b8c', // Traffic blue
+  'RAL 5018': '#048b8c', // Turquoise blue
+  'RAL 5019': '#005e83', // Capri blue
+  'RAL 5020': '#00414b', // Ocean blue
+  'RAL 5021': '#007577', // Water blue
+  'RAL 5022': '#222d5a', // Night blue
+  'RAL 5023': '#41698c', // Distant blue
+  'RAL 5024': '#6093ac', // Pastel blue
+  'RAL 5025': '#20697c', // Pearl gentian blue
+  'RAL 5026': '#0f3052', // Pearl night blue
+  // --- Greens (RAL 6000-RAL 6039; 37 entries) ---
+  'RAL 6000': '#3c7460', // Patina green
+  'RAL 6001': '#366735', // Emerald green
+  'RAL 6002': '#325928', // Leaf green
+  'RAL 6003': '#50533c', // Olive green
+  'RAL 6004': '#024442', // Blue green
+  'RAL 6005': '#114232', // Moss green
+  'RAL 6006': '#3c392e', // Grey olive
+  'RAL 6007': '#2c3222', // Bottle green
+  'RAL 6008': '#36342a', // Brown green
+  'RAL 6009': '#27352a', // Fir green
+  'RAL 6010': '#4d6f39', // Grass green
+  'RAL 6011': '#6b7c59', // Reseda green
+  'RAL 6012': '#2f3d3a', // Black green
+  'RAL 6013': '#7c765a', // Reed green
+  'RAL 6014': '#474135', // Yellow olive
+  'RAL 6015': '#3d3d36', // Black olive
+  'RAL 6016': '#00694c', // Turquoise green
+  'RAL 6017': '#587f40', // May green
+  'RAL 6018': '#60993b', // Yellow green
+  'RAL 6019': '#b9ceac', // Pastel green
+  'RAL 6020': '#37422f', // Chrome green
+  'RAL 6021': '#8a9977', // Pale green
+  'RAL 6022': '#3a3327', // Olive drab
+  'RAL 6024': '#008351', // Traffic green
+  'RAL 6025': '#5e6e3b', // Fern green
+  'RAL 6026': '#005f4e', // Opal green
+  'RAL 6027': '#7ebab5', // Light green
+  'RAL 6028': '#315442', // Pine green
+  'RAL 6029': '#006f3d', // Mint green
+  'RAL 6032': '#237f52', // Signal green
+  'RAL 6033': '#45877f', // Mint turquoise
+  'RAL 6034': '#7aadac', // Pastel turquoise
+  'RAL 6035': '#194d25', // Pearl green
+  'RAL 6036': '#04574b', // Pearl opal green
+  'RAL 6037': '#008b29', // Pure green
+  'RAL 6038': '#00b51b', // Luminous green
+  'RAL 6039': '#b3c43e', // Fibrous green
+  // --- Greys (RAL 7000-RAL 7048; 38 entries) ---
+  'RAL 7000': '#7a888e', // Squirrel grey
+  'RAL 7001': '#8c979c', // Silver grey
+  'RAL 7002': '#817863', // Olive grey
+  'RAL 7003': '#797669', // Moss grey
+  'RAL 7004': '#9a9b9b', // Signal grey
+  'RAL 7005': '#6b6e6b', // Mouse grey
+  'RAL 7006': '#766a5e', // Beige grey
+  'RAL 7008': '#745f3d', // Khaki grey
+  'RAL 7009': '#5d6058', // Green grey
+  'RAL 7010': '#585c56', // Tarpaulin grey
+  'RAL 7011': '#52595d', // Iron grey
+  'RAL 7012': '#575d5e', // Basalt grey
+  'RAL 7013': '#575044', // Brown grey
+  'RAL 7015': '#4f5358', // Slate grey
+  'RAL 7016': '#383e42', // Anthracite grey
+  'RAL 7021': '#2f3234', // Black grey
+  'RAL 7022': '#4c4a44', // Umbra grey
+  'RAL 7023': '#808076', // Concrete grey
+  'RAL 7024': '#45494e', // Graphite grey
+  'RAL 7026': '#374345', // Granite grey
+  'RAL 7030': '#928e85', // Stone grey
+  'RAL 7031': '#5b686d', // Blue grey
+  'RAL 7032': '#b5b0a1', // Pebble grey
+  'RAL 7033': '#7f8274', // Cement grey
+  'RAL 7034': '#92886f', // Yellow grey
+  'RAL 7035': '#c5c7c4', // Light grey
+  'RAL 7036': '#979392', // Platinum grey
+  'RAL 7037': '#7a7b7a', // Dusty grey
+  'RAL 7038': '#b0b0a9', // Agate grey
+  'RAL 7039': '#6b665e', // Quartz grey
+  'RAL 7040': '#989ea1', // Window grey
+  'RAL 7042': '#8e9291', // Traffic grey A
+  'RAL 7043': '#4f5250', // Traffic grey B
+  'RAL 7044': '#b7b3a8', // Silk grey
+  'RAL 7045': '#8d9295', // Telegrey 1
+  'RAL 7046': '#7e868a', // Telegrey 2
+  'RAL 7047': '#c8c8c7', // Telegrey 4
+  'RAL 7048': '#817b73', // Pearl mouse grey
+  // --- Browns (RAL 8000-RAL 8029; 20 entries) ---
+  'RAL 8000': '#89693f', // Green brown
+  'RAL 8001': '#9d622b', // Ochre brown
+  'RAL 8002': '#794d3e', // Signal brown
+  'RAL 8003': '#7e4b27', // Clay brown
+  'RAL 8004': '#8d4931', // Copper brown
+  'RAL 8007': '#70462b', // Fawn brown
+  'RAL 8008': '#724a25', // Olive brown
+  'RAL 8011': '#5a3827', // Nut brown
+  'RAL 8012': '#66332b', // Red brown
+  'RAL 8014': '#4a3526', // Sepia brown
+  'RAL 8015': '#5e2f26', // Chestnut brown
+  'RAL 8016': '#4c2b20', // Mahogany brown
+  'RAL 8017': '#442f29', // Chocolate brown
+  'RAL 8019': '#3d3635', // Grey brown
+  'RAL 8022': '#1a1719', // Black brown
+  'RAL 8023': '#a45729', // Orange brown
+  'RAL 8024': '#795038', // Beige brown
+  'RAL 8025': '#755847', // Pale brown
+  'RAL 8028': '#513a2a', // Terra brown
+  'RAL 8029': '#7f4031', // Pearl copper
+  // --- Whites and Blacks (RAL 9001-RAL 9023; 15 entries) ---
+  'RAL 9001': '#e9e0d2', // Cream
+  'RAL 9002': '#d6d5cb', // Grey white
+  'RAL 9003': '#ecece7', // Signal white
+  'RAL 9004': '#2b2b2c', // Signal black
+  'RAL 9005': '#0e0e10', // Jet black
+  'RAL 9006': '#a1a1a0', // White aluminium
+  'RAL 9007': '#868581', // Grey aluminium
+  'RAL 9010': '#f1ede1', // Pure white
+  'RAL 9011': '#27292b', // Graphite black
+  'RAL 9012': '#f8f2e1', // Cleanroom white
+  'RAL 9016': '#f1f1ea', // Traffic white
+  'RAL 9017': '#29292a', // Traffic black
+  'RAL 9018': '#c8cbc4', // Papyrus white
+  'RAL 9022': '#858583', // Pearl light grey
+  'RAL 9023': '#787b7a', // Pearl dark grey
+} as const;
+
+export type RalColorName = keyof typeof ralColors;
+
+/**
+ * RAL Classic as a `Palette<RalColorName>`. 216 entries spanning
+ * RAL 1000-RAL 9023 across ten color groups. Keys are RAL codes
+ * ('RAL 1000', 'RAL 9023'); the English color name is in source-side
+ * comments for skimmers. Default metric is `'deltaE2000'`.
+ *
+ * @example
+ * identify('#27292b', { palette: ral });               // 'RAL 9011' (Graphite black)
+ * resolve('RAL 5002', { palette: ral });               // '#00387a' (Ultramarine blue)
+ * ral.colors['RAL 1003'];                              // '#f9a900' (Signal yellow)
+ */
+export const ral = {
+  name: 'ral',
+  colors: ralColors,
+  normalize: standardNormalize,
+  defaultMetric: 'deltaE2000',
+} as const satisfies Palette<RalColorName>;

--- a/src/palettes/tailwind.ts
+++ b/src/palettes/tailwind.ts
@@ -1,0 +1,321 @@
+import type { Palette } from '../types.js';
+import { standardNormalize } from './normalize.js';
+
+/**
+ * Tailwind CSS default theme colors (v4.0 baseline).
+ *
+ * The 22 default color families × 11 shades = 242 entries:
+ *
+ *  - Neutrals: slate, gray, zinc, neutral, stone
+ *  - Hues: red, orange, amber, yellow, lime, green, emerald, teal, cyan,
+ *    sky, blue, indigo, violet, purple, fuchsia, pink, rose
+ *
+ * Shades are the canonical 50, 100, 200, 300, 400, 500, 600, 700, 800,
+ * 900, 950 ramp. Keys are the Tailwind class suffix verbatim: `'slate-500'`,
+ * `'rose-950'`. `standardNormalize` strips the hyphen, so `resolve('slate500')`,
+ * `resolve('SLATE-500')`, and `resolve('slate-500')` all hit the same entry.
+ *
+ * sRGB values are computed from Tailwind v4.0's OKLCH theme spec (the v4
+ * default-theme file ships OKLCH, not hex). OKLAB→linear sRGB via Björn
+ * Ottosson's reference matrix; sRGB transfer function per IEC 61966-2-1.
+ * Out-of-gamut OKLCH values are clamped to [0, 1] before encoding —
+ * affects mostly the saturated 500-600 shades in the red/orange/pink/rose
+ * families, where v4 deliberately pushes past sRGB's gamut boundary
+ * (P3-aware browsers render brighter; sRGB consumers see the clamped hex).
+ *
+ * Excluded: black, white, transparent, currentcolor, inherit. The first
+ * two are trivially representable as `'#000000'` / `'#ffffff'` and aren't
+ * "named tokens" in the design-system sense; the rest aren't sRGB colors.
+ * Tailwind v4.2+ families (mauve, olive, mist, taupe) are deferred to a
+ * future bump; this palette pins to v4.0 per the issue.
+ *
+ * Default metric: `deltaEok`. Tailwind defines its shades on an OKLCH
+ * lightness ramp; OKLAB-based distance recovers the same perceptual
+ * structure better than CIELAB76.
+ */
+const tailwindColors = {
+  // --- slate ---
+  'slate-50': '#f8fafc',
+  'slate-100': '#f1f5f9',
+  'slate-200': '#e2e8f0',
+  'slate-300': '#cad5e2',
+  'slate-400': '#90a1b9',
+  'slate-500': '#62748e',
+  'slate-600': '#45556c',
+  'slate-700': '#314158',
+  'slate-800': '#1d293d',
+  'slate-900': '#0f172b',
+  'slate-950': '#020618',
+  // --- gray ---
+  'gray-50': '#f9fafb',
+  'gray-100': '#f3f4f6',
+  'gray-200': '#e5e7eb',
+  'gray-300': '#d1d5dc',
+  'gray-400': '#99a1af',
+  'gray-500': '#6a7282',
+  'gray-600': '#4a5565',
+  'gray-700': '#364153',
+  'gray-800': '#1e2939',
+  'gray-900': '#101828',
+  'gray-950': '#030712',
+  // --- zinc ---
+  'zinc-50': '#fafafa',
+  'zinc-100': '#f4f4f5',
+  'zinc-200': '#e4e4e7',
+  'zinc-300': '#d4d4d8',
+  'zinc-400': '#9f9fa9',
+  'zinc-500': '#71717b',
+  'zinc-600': '#52525c',
+  'zinc-700': '#3f3f46',
+  'zinc-800': '#27272a',
+  'zinc-900': '#18181b',
+  'zinc-950': '#09090b',
+  // --- neutral ---
+  'neutral-50': '#fafafa',
+  'neutral-100': '#f5f5f5',
+  'neutral-200': '#e5e5e5',
+  'neutral-300': '#d4d4d4',
+  'neutral-400': '#a1a1a1',
+  'neutral-500': '#737373',
+  'neutral-600': '#525252',
+  'neutral-700': '#404040',
+  'neutral-800': '#262626',
+  'neutral-900': '#171717',
+  'neutral-950': '#0a0a0a',
+  // --- stone ---
+  'stone-50': '#fafaf9',
+  'stone-100': '#f5f5f4',
+  'stone-200': '#e7e5e4',
+  'stone-300': '#d6d3d1',
+  'stone-400': '#a6a09b',
+  'stone-500': '#79716b',
+  'stone-600': '#57534d',
+  'stone-700': '#44403b',
+  'stone-800': '#292524',
+  'stone-900': '#1c1917',
+  'stone-950': '#0c0a09',
+  // --- red ---
+  'red-50': '#fef2f2',
+  'red-100': '#ffe2e2',
+  'red-200': '#ffc9c9',
+  'red-300': '#ffa2a2',
+  'red-400': '#ff6467',
+  'red-500': '#fb2c36',
+  'red-600': '#e7000b',
+  'red-700': '#c10007',
+  'red-800': '#9f0712',
+  'red-900': '#82181a',
+  'red-950': '#460809',
+  // --- orange ---
+  'orange-50': '#fff7ed',
+  'orange-100': '#ffedd4',
+  'orange-200': '#ffd6a7',
+  'orange-300': '#ffb86a',
+  'orange-400': '#ff8904',
+  'orange-500': '#ff6900',
+  'orange-600': '#f54900',
+  'orange-700': '#ca3500',
+  'orange-800': '#9f2d00',
+  'orange-900': '#7e2a0c',
+  'orange-950': '#441306',
+  // --- amber ---
+  'amber-50': '#fffbeb',
+  'amber-100': '#fef3c6',
+  'amber-200': '#fee685',
+  'amber-300': '#ffd230',
+  'amber-400': '#ffb900',
+  'amber-500': '#fe9a00',
+  'amber-600': '#e17100',
+  'amber-700': '#bb4d00',
+  'amber-800': '#973c00',
+  'amber-900': '#7b3306',
+  'amber-950': '#461901',
+  // --- yellow ---
+  'yellow-50': '#fefce8',
+  'yellow-100': '#fef9c2',
+  'yellow-200': '#fff085',
+  'yellow-300': '#ffdf20',
+  'yellow-400': '#fdc700',
+  'yellow-500': '#f0b100',
+  'yellow-600': '#d08700',
+  'yellow-700': '#a65f00',
+  'yellow-800': '#894b00',
+  'yellow-900': '#733e0a',
+  'yellow-950': '#432004',
+  // --- lime ---
+  'lime-50': '#f7fee7',
+  'lime-100': '#ecfcca',
+  'lime-200': '#d8f999',
+  'lime-300': '#bbf451',
+  'lime-400': '#9ae600',
+  'lime-500': '#7ccf00',
+  'lime-600': '#5ea500',
+  'lime-700': '#497d00',
+  'lime-800': '#3c6300',
+  'lime-900': '#35530e',
+  'lime-950': '#192e03',
+  // --- green ---
+  'green-50': '#f0fdf4',
+  'green-100': '#dcfce7',
+  'green-200': '#b9f8cf',
+  'green-300': '#7bf1a8',
+  'green-400': '#05df72',
+  'green-500': '#00c950',
+  'green-600': '#00a63e',
+  'green-700': '#008236',
+  'green-800': '#016630',
+  'green-900': '#0d542b',
+  'green-950': '#032e15',
+  // --- emerald ---
+  'emerald-50': '#ecfdf5',
+  'emerald-100': '#d0fae5',
+  'emerald-200': '#a4f4cf',
+  'emerald-300': '#5ee9b5',
+  'emerald-400': '#00d492',
+  'emerald-500': '#00bc7d',
+  'emerald-600': '#009966',
+  'emerald-700': '#007a55',
+  'emerald-800': '#006045',
+  'emerald-900': '#004f3b',
+  'emerald-950': '#002c22',
+  // --- teal ---
+  'teal-50': '#f0fdfa',
+  'teal-100': '#cbfbf1',
+  'teal-200': '#96f7e4',
+  'teal-300': '#46ecd5',
+  'teal-400': '#00d5be',
+  'teal-500': '#00bba7',
+  'teal-600': '#009689',
+  'teal-700': '#00786f',
+  'teal-800': '#005f5a',
+  'teal-900': '#0b4f4a',
+  'teal-950': '#022f2e',
+  // --- cyan ---
+  'cyan-50': '#ecfeff',
+  'cyan-100': '#cefafe',
+  'cyan-200': '#a2f4fd',
+  'cyan-300': '#53eafd',
+  'cyan-400': '#00d3f2',
+  'cyan-500': '#00b8db',
+  'cyan-600': '#0092b8',
+  'cyan-700': '#007595',
+  'cyan-800': '#005f78',
+  'cyan-900': '#104e64',
+  'cyan-950': '#053345',
+  // --- sky ---
+  'sky-50': '#f0f9ff',
+  'sky-100': '#dff2fe',
+  'sky-200': '#b8e6fe',
+  'sky-300': '#74d4ff',
+  'sky-400': '#00bcff',
+  'sky-500': '#00a6f4',
+  'sky-600': '#0084d1',
+  'sky-700': '#0069a8',
+  'sky-800': '#00598a',
+  'sky-900': '#024a70',
+  'sky-950': '#052f4a',
+  // --- blue ---
+  'blue-50': '#eff6ff',
+  'blue-100': '#dbeafe',
+  'blue-200': '#bedbff',
+  'blue-300': '#8ec5ff',
+  'blue-400': '#51a2ff',
+  'blue-500': '#2b7fff',
+  'blue-600': '#155dfc',
+  'blue-700': '#1447e6',
+  'blue-800': '#193cb8',
+  'blue-900': '#1c398e',
+  'blue-950': '#162456',
+  // --- indigo ---
+  'indigo-50': '#eef2ff',
+  'indigo-100': '#e0e7ff',
+  'indigo-200': '#c6d2ff',
+  'indigo-300': '#a3b3ff',
+  'indigo-400': '#7c86ff',
+  'indigo-500': '#615fff',
+  'indigo-600': '#4f39f6',
+  'indigo-700': '#432dd7',
+  'indigo-800': '#372aac',
+  'indigo-900': '#312c85',
+  'indigo-950': '#1e1a4d',
+  // --- violet ---
+  'violet-50': '#f5f3ff',
+  'violet-100': '#ede9fe',
+  'violet-200': '#ddd6ff',
+  'violet-300': '#c4b4ff',
+  'violet-400': '#a684ff',
+  'violet-500': '#8e51ff',
+  'violet-600': '#7f22fe',
+  'violet-700': '#7008e7',
+  'violet-800': '#5d0ec0',
+  'violet-900': '#4d179a',
+  'violet-950': '#2f0d68',
+  // --- purple ---
+  'purple-50': '#faf5ff',
+  'purple-100': '#f3e8ff',
+  'purple-200': '#e9d4ff',
+  'purple-300': '#dab2ff',
+  'purple-400': '#c27aff',
+  'purple-500': '#ad46ff',
+  'purple-600': '#9810fa',
+  'purple-700': '#8200db',
+  'purple-800': '#6e11b0',
+  'purple-900': '#59168b',
+  'purple-950': '#3c0366',
+  // --- fuchsia ---
+  'fuchsia-50': '#fdf4ff',
+  'fuchsia-100': '#fae8ff',
+  'fuchsia-200': '#f6cfff',
+  'fuchsia-300': '#f4a8ff',
+  'fuchsia-400': '#ed6aff',
+  'fuchsia-500': '#e12afb',
+  'fuchsia-600': '#c800de',
+  'fuchsia-700': '#a800b7',
+  'fuchsia-800': '#8a0194',
+  'fuchsia-900': '#721378',
+  'fuchsia-950': '#4b004f',
+  // --- pink ---
+  'pink-50': '#fdf2f8',
+  'pink-100': '#fce7f3',
+  'pink-200': '#fccee8',
+  'pink-300': '#fda5d5',
+  'pink-400': '#fb64b6',
+  'pink-500': '#f6339a',
+  'pink-600': '#e60076',
+  'pink-700': '#c6005c',
+  'pink-800': '#a3004c',
+  'pink-900': '#861043',
+  'pink-950': '#510424',
+  // --- rose ---
+  'rose-50': '#fff1f2',
+  'rose-100': '#ffe4e6',
+  'rose-200': '#ffccd3',
+  'rose-300': '#ffa1ad',
+  'rose-400': '#ff637e',
+  'rose-500': '#ff2056',
+  'rose-600': '#ec003f',
+  'rose-700': '#c70036',
+  'rose-800': '#a50036',
+  'rose-900': '#8b0836',
+  'rose-950': '#4d0218',
+} as const;
+
+export type TailwindColorName = keyof typeof tailwindColors;
+
+/**
+ * Tailwind CSS default theme as a `Palette<TailwindColorName>`. 22
+ * families × 11 shades = 242 entries from the v4.0 baseline. Keys
+ * are the Tailwind class suffix (`'sky-500'`); standard normalizer
+ * accepts the hyphen, lowercase, or punctuation-free forms.
+ *
+ * @example
+ * identify('#62748e', { palette: tailwind });          // 'slate-500'
+ * resolve('rose-500', { palette: tailwind });          // '#ff2056'
+ * tailwind.colors['blue-600'];                         // sRGB hex
+ */
+export const tailwind = {
+  name: 'tailwind',
+  colors: tailwindColors,
+  normalize: standardNormalize,
+  defaultMetric: 'deltaEok',
+} as const satisfies Palette<TailwindColorName>;

--- a/src/palettes/werner.ts
+++ b/src/palettes/werner.ts
@@ -1,0 +1,172 @@
+import type { Palette } from '../types.js';
+import { standardNormalize } from './normalize.js';
+
+/**
+ * Werner's Nomenclature of Colours (1821) — Patrick Syme's adaptation of
+ * Abraham Werner's mineralogical color system, famously the reference
+ * Charles Darwin carried aboard HMS Beagle.
+ *
+ * 110 named pigments organized into ten classes (Whites, Greys, Blacks,
+ * Blues, Purples, Greens, Yellows, Oranges, Reds, Browns). Each name is
+ * a piece of natural-history vocabulary: animal/vegetable/mineral
+ * exemplars rather than abstract color labels (`'Lake Red'` is named
+ * for the dark spot on a ladybird; `'Verdigris Green'` for the patina
+ * on weathered copper).
+ *
+ * Keys are Title Case ('Snow White', 'Berlin Blue', 'Tile Red') matching
+ * the 1821 typography. `standardNormalize` strips case and punctuation
+ * on input, so `resolve('snow-white')`, `resolve('SNOW WHITE')`, and
+ * `resolve('Snow White')` all hit the same entry.
+ *
+ * sRGB values are taken from Nicholas Rougeux's CC-BY digitization at
+ * <https://www.c82.net/werner/>, which photographed and sampled the
+ * original chip swatches. See NOTICE.md for attribution and license.
+ *
+ * Default metric: `deltaE2000`. The palette is mostly muted earth tones
+ * and pigment darks; subtle perceptual distinctions matter more than
+ * the cheap-fast ΔE76 can resolve.
+ */
+const wernerColors = {
+  // --- Whites (#1-8) ---
+  'Snow White': '#f1e9cd',
+  'Reddish White': '#f2e7cf',
+  'Purplish White': '#ece6d0',
+  'Yellowish White': '#f2eacc',
+  'Orange coloured White': '#f3e9ca',
+  'Greenish White': '#f2ebcd',
+  'Skimmed milk White': '#e6e1c9',
+  'Greyish White': '#e2ddc6',
+  // --- Greys (#9-16) ---
+  'Ash Grey': '#cbc8b7',
+  'Smoke Grey': '#bfbbb0',
+  'French Grey': '#bebeb3',
+  'Pearl Grey': '#b7b5ac',
+  'Yellowish Grey': '#bab191',
+  'Bluish Grey': '#9c9d9a',
+  'Greenish Grey': '#8a8d84',
+  'Blackish Grey': '#5b5c61',
+  // --- Blacks (#17-23) ---
+  'Greyish Black': '#555152',
+  'Bluish Black': '#413f44',
+  'Greenish Black': '#454445',
+  'Pitch or Brownish Black': '#423937',
+  'Reddish Black': '#433635',
+  'Ink Black': '#252024',
+  'Velvet Black': '#241f20',
+  // --- Blues (#24-34) ---
+  'Scotch Blue': '#281f3f',
+  'Prussian Blue': '#1c1949',
+  'Indigo Blue': '#4f638d',
+  'China Blue': '#383867',
+  'Azure Blue': '#5c6b8f',
+  'Ultramarine Blue': '#657abb',
+  'Flax-Flower Blue': '#6f88af',
+  'Berlin Blue': '#7994b5',
+  'Verditter Blue': '#6fb5a8',
+  'Greenish Blue': '#719ba2',
+  'Greyish Blue': '#8aa1a6',
+  // --- Purples (#35-45) ---
+  'Bluish Lilac Purple': '#d0d5d3',
+  'Bluish Purple': '#8590ae',
+  'Violet Purple': '#3a2f52',
+  'Pansy Purple': '#39334a',
+  'Campanula Purple': '#6c6d94',
+  'Imperial Purple': '#584c77',
+  'Auricula Purple': '#533552',
+  'Plum Purple': '#463759',
+  'Red Lilac Purple': '#bfbac0',
+  'Lavender Purple': '#77747f',
+  'Pale Blackish Purple': '#4a475c',
+  // --- Greens (#46-61) ---
+  'Celadine Green': '#b8bfaf',
+  'Mountain Green': '#b2b599',
+  'Leek Green': '#979c84',
+  'Blackish Green': '#5d6161',
+  'Verdigris Green': '#61ac86',
+  'Bluish Green': '#a4b6a7',
+  'Apple Green': '#adba98',
+  'Emerald Green': '#93b778',
+  'Grass Green': '#7d8c55',
+  'Duck Green': '#33431e',
+  'Sap Green': '#7c8635',
+  'Pistachio Green': '#8e9849',
+  'Asparagus Green': '#c2c190',
+  'Olive Green': '#67765b',
+  'Oil Green': '#ab924b',
+  'Siskin Green': '#c8c76f',
+  // --- Yellows (#62-75) ---
+  'Sulphur Yellow': '#ccc050',
+  'Primrose Yellow': '#ebdd99',
+  'Wax Yellow': '#ab9649',
+  'Lemon Yellow': '#dbc364',
+  'Gamboge Yellow': '#e6d058',
+  'Kings Yellow': '#ead665',
+  'Saffron Yellow': '#d09b2c',
+  'Gallstone Yellow': '#a36629',
+  'Honey Yellow': '#a77d35',
+  'Straw Yellow': '#f0d696',
+  'Wine Yellow': '#d7c485',
+  'Sienna Yellow': '#f1d28c',
+  'Ochre Yellow': '#efcc83',
+  'Cream Yellow': '#f3daa7',
+  // --- Oranges (#76-81) ---
+  'Dutch Orange': '#dfa837',
+  'Buff Orange': '#ebbc71',
+  'Orpiment Orange': '#d17c3f',
+  'Brownish Orange': '#92462f',
+  'Reddish Orange': '#be7249',
+  'Deep Reddish Orange': '#bb603c',
+  // --- Reds (#82-99) ---
+  'Tile Red': '#c76b4a',
+  'Hyacinth Red': '#a75536',
+  'Scarlet Red': '#b63e36',
+  'Vermilion Red': '#b5493a',
+  'Aurora Red': '#cd6d57',
+  'Arterial Blood Red': '#711518',
+  'Flesh Red': '#e9c49d',
+  'Rose Red': '#eedac3',
+  'Peach Blossom Red': '#eecfbf',
+  'Carmine Red': '#ce536b',
+  'Lake Red': '#b74a70',
+  'Crimson Red': '#b7757c',
+  'Purplish Red': '#612741',
+  'Cochineal Red': '#7a4848',
+  'Veinous Blood Red': '#3f3033',
+  'Brownish Purple Red': '#8d746f',
+  'Chocolate Red': '#4d3635',
+  'Brownish Red': '#6e3b31',
+  // --- Browns (#100-110) ---
+  'Deep Orange-coloured Brown': '#864735',
+  'Deep Reddish Brown': '#553d3a',
+  'Umber Brown': '#613936',
+  'Chestnut Brown': '#7a4b3a',
+  'Yellowish Brown': '#946943',
+  'Wood Brown': '#c39e6d',
+  'Liver Brown': '#513e32',
+  'Hair Brown': '#8b7859',
+  'Broccoli Brown': '#9b856b',
+  'Clove Brown': '#766051',
+  'Blackish Brown': '#453b32',
+} as const;
+
+export type WernerColorName = keyof typeof wernerColors;
+
+/**
+ * Werner's Nomenclature of Colours (1821) as a `Palette<WernerColorName>`.
+ *
+ * 110 entries spanning ten Werner classes (Whites → Browns). Keys are
+ * the original 1821 names ('Berlin Blue', 'Lake Red'). Default metric
+ * is `'deltaE2000'`: the palette's muted earth-tone distribution rewards
+ * perceptually uniform comparisons over fast Euclidean distance.
+ *
+ * @example
+ * identify('#1c1949', { palette: werner });            // 'Prussian Blue'
+ * resolve('Berlin Blue', { palette: werner });         // '#7994b5'
+ * werner.colors['Lake Red'];                           // '#b74a70'
+ */
+export const werner = {
+  name: 'werner',
+  colors: wernerColors,
+  normalize: standardNormalize,
+  defaultMetric: 'deltaE2000',
+} as const satisfies Palette<WernerColorName>;

--- a/test/palettes.test.ts
+++ b/test/palettes.test.ts
@@ -9,6 +9,7 @@ import { ntc } from '../src/palettes/ntc.js';
 import { pantone } from '../src/palettes/pantone.js';
 import { pokemon } from '../src/palettes/pokemon.js';
 import { resene } from '../src/palettes/resene.js';
+import { tailwind } from '../src/palettes/tailwind.js';
 import { web } from '../src/palettes/web.js';
 import { werner } from '../src/palettes/werner.js';
 import { x11 } from '../src/palettes/x11.js';
@@ -150,6 +151,19 @@ describe.each([
         'Prussian Blue': '#1c1949',
         'Lake Red': '#b74a70',
         'Velvet Black': '#241f20',
+      } as Record<string, string>,
+    },
+  ],
+  [
+    'tailwind',
+    tailwind,
+    {
+      minCount: 242,
+      spotChecks: {
+        'slate-500': '#62748e',
+        'rose-500': '#ff2056',
+        'gray-50': '#f9fafb',
+        'blue-600': '#155dfc',
       } as Record<string, string>,
     },
   ],

--- a/test/palettes.test.ts
+++ b/test/palettes.test.ts
@@ -8,6 +8,7 @@ import { ncs } from '../src/palettes/ncs.js';
 import { ntc } from '../src/palettes/ntc.js';
 import { pantone } from '../src/palettes/pantone.js';
 import { pokemon } from '../src/palettes/pokemon.js';
+import { ral } from '../src/palettes/ral.js';
 import { resene } from '../src/palettes/resene.js';
 import { tailwind } from '../src/palettes/tailwind.js';
 import { web } from '../src/palettes/web.js';
@@ -164,6 +165,19 @@ describe.each([
         'rose-500': '#ff2056',
         'gray-50': '#f9fafb',
         'blue-600': '#155dfc',
+      } as Record<string, string>,
+    },
+  ],
+  [
+    'ral',
+    ral,
+    {
+      minCount: 215,
+      spotChecks: {
+        'RAL 1003': '#f9a900',
+        'RAL 5002': '#00387a',
+        'RAL 9005': '#0e0e10',
+        'RAL 9011': '#27292b',
       } as Record<string, string>,
     },
   ],

--- a/test/palettes.test.ts
+++ b/test/palettes.test.ts
@@ -10,6 +10,7 @@ import { pantone } from '../src/palettes/pantone.js';
 import { pokemon } from '../src/palettes/pokemon.js';
 import { resene } from '../src/palettes/resene.js';
 import { web } from '../src/palettes/web.js';
+import { werner } from '../src/palettes/werner.js';
 import { x11 } from '../src/palettes/x11.js';
 import { xkcd } from '../src/palettes/xkcd.js';
 
@@ -136,6 +137,19 @@ describe.each([
         Fire: '#ee8130',
         Water: '#6390f0',
         Fairy: '#d685ad',
+      } as Record<string, string>,
+    },
+  ],
+  [
+    'werner',
+    werner,
+    {
+      minCount: 110,
+      spotChecks: {
+        'Berlin Blue': '#7994b5',
+        'Prussian Blue': '#1c1949',
+        'Lake Red': '#b74a70',
+        'Velvet Black': '#241f20',
       } as Record<string, string>,
     },
   ],

--- a/test/palettes.test.ts
+++ b/test/palettes.test.ts
@@ -7,6 +7,7 @@ import { nbs } from '../src/palettes/nbs.js';
 import { ncs } from '../src/palettes/ncs.js';
 import { ntc } from '../src/palettes/ntc.js';
 import { pantone } from '../src/palettes/pantone.js';
+import { pokemon } from '../src/palettes/pokemon.js';
 import { resene } from '../src/palettes/resene.js';
 import { web } from '../src/palettes/web.js';
 import { x11 } from '../src/palettes/x11.js';
@@ -123,6 +124,18 @@ describe.each([
       spotChecks: {
         '0500-N': '#f2f2f2',
         '2030-R80B': '#677bd6',
+      } as Record<string, string>,
+    },
+  ],
+  [
+    'pokemon',
+    pokemon,
+    {
+      minCount: 18,
+      spotChecks: {
+        Fire: '#ee8130',
+        Water: '#6390f0',
+        Fairy: '#d685ad',
       } as Record<string, string>,
     },
   ],

--- a/test/subpathExports.test.ts
+++ b/test/subpathExports.test.ts
@@ -141,6 +141,13 @@ maybe('subpath exports resolve', () => {
     expect(m.pokemon.defaultMetric).toBe('deltaE76');
   });
 
+  it('chromonym/werner exports the werner palette object', async () => {
+    const m = await import('../dist/palettes/werner.js');
+    expect(m.werner.name).toBe('werner');
+    expect(m.werner.colors['Prussian Blue']).toBe('#1c1949');
+    expect(m.werner.defaultMetric).toBe('deltaE2000');
+  });
+
   it('chromonym/conversions/hex exports hexToRgba / rgbaToHex', async () => {
     const m = await import('../dist/conversions/hex.js');
     expect(m.hexToRgba('#ff0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
@@ -235,6 +242,7 @@ maybe('subpath exports resolve', () => {
       "const { ncs } = await import('chromonym/ncs');",
       "const { nbs } = await import('chromonym/nbs');",
       "const { pokemon } = await import('chromonym/pokemon');",
+      "const { werner } = await import('chromonym/werner');",
       "const { hexToRgba } = await import('chromonym/conversions/hex');",
       "const { rgbToRgba } = await import('chromonym/conversions/rgb');",
       "const { hslToRgba } = await import('chromonym/conversions/hsl');",
@@ -258,6 +266,7 @@ maybe('subpath exports resolve', () => {
       '  ncsNeutral: ncs.colors["0500-N"] === "#f2f2f2",',
       '  nbsVividPink: nbs.colors.vividpink === "#ffb5ba",',
       '  pokemonFire: pokemon.colors.Fire === "#ee8130",',
+      '  wernerPrussian: werner.colors["Prussian Blue"] === "#1c1949",',
       "  hexToRgba: hexToRgba('#ff0000').r === 255,",
       '  rgb: rgbToRgba([1,2,3]).r === 1,',
       '  hsl: hslToRgba({ h: 0, s: 100, l: 50 }).r === 255,',
@@ -294,6 +303,7 @@ maybe('subpath exports resolve', () => {
       ncsNeutral: true,
       nbsVividPink: true,
       pokemonFire: true,
+      wernerPrussian: true,
       hexToRgba: true,
       rgb: true,
       hsl: true,

--- a/test/subpathExports.test.ts
+++ b/test/subpathExports.test.ts
@@ -156,6 +156,13 @@ maybe('subpath exports resolve', () => {
     expect(m.tailwind.defaultMetric).toBe('deltaEok');
   });
 
+  it('chromonym/ral exports the ral palette object', async () => {
+    const m = await import('../dist/palettes/ral.js');
+    expect(m.ral.name).toBe('ral');
+    expect(m.ral.colors['RAL 1003']).toBe('#f9a900');
+    expect(m.ral.defaultMetric).toBe('deltaE2000');
+  });
+
   it('chromonym/conversions/hex exports hexToRgba / rgbaToHex', async () => {
     const m = await import('../dist/conversions/hex.js');
     expect(m.hexToRgba('#ff0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
@@ -252,6 +259,7 @@ maybe('subpath exports resolve', () => {
       "const { pokemon } = await import('chromonym/pokemon');",
       "const { werner } = await import('chromonym/werner');",
       "const { tailwind } = await import('chromonym/tailwind');",
+      "const { ral } = await import('chromonym/ral');",
       "const { hexToRgba } = await import('chromonym/conversions/hex');",
       "const { rgbToRgba } = await import('chromonym/conversions/rgb');",
       "const { hslToRgba } = await import('chromonym/conversions/hsl');",
@@ -277,6 +285,7 @@ maybe('subpath exports resolve', () => {
       '  pokemonFire: pokemon.colors.Fire === "#ee8130",',
       '  wernerPrussian: werner.colors["Prussian Blue"] === "#1c1949",',
       '  tailwindSlate: tailwind.colors["slate-500"] === "#62748e",',
+      '  ralSignalYellow: ral.colors["RAL 1003"] === "#f9a900",',
       "  hexToRgba: hexToRgba('#ff0000').r === 255,",
       '  rgb: rgbToRgba([1,2,3]).r === 1,',
       '  hsl: hslToRgba({ h: 0, s: 100, l: 50 }).r === 255,',
@@ -315,6 +324,7 @@ maybe('subpath exports resolve', () => {
       pokemonFire: true,
       wernerPrussian: true,
       tailwindSlate: true,
+      ralSignalYellow: true,
       hexToRgba: true,
       rgb: true,
       hsl: true,

--- a/test/subpathExports.test.ts
+++ b/test/subpathExports.test.ts
@@ -134,6 +134,13 @@ maybe('subpath exports resolve', () => {
     expect(m.ncs.normalize('0500-N')).toBe('0500n');
   });
 
+  it('chromonym/pokemon exports the pokemon palette object', async () => {
+    const m = await import('../dist/palettes/pokemon.js');
+    expect(m.pokemon.name).toBe('pokemon');
+    expect(m.pokemon.colors.Fire).toBe('#ee8130');
+    expect(m.pokemon.defaultMetric).toBe('deltaE76');
+  });
+
   it('chromonym/conversions/hex exports hexToRgba / rgbaToHex', async () => {
     const m = await import('../dist/conversions/hex.js');
     expect(m.hexToRgba('#ff0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
@@ -227,6 +234,7 @@ maybe('subpath exports resolve', () => {
       "const { resene } = await import('chromonym/resene');",
       "const { ncs } = await import('chromonym/ncs');",
       "const { nbs } = await import('chromonym/nbs');",
+      "const { pokemon } = await import('chromonym/pokemon');",
       "const { hexToRgba } = await import('chromonym/conversions/hex');",
       "const { rgbToRgba } = await import('chromonym/conversions/rgb');",
       "const { hslToRgba } = await import('chromonym/conversions/hsl');",
@@ -249,6 +257,7 @@ maybe('subpath exports resolve', () => {
       '  reseneTreepoppy: resene.colors.treepoppy === "#e2813b",',
       '  ncsNeutral: ncs.colors["0500-N"] === "#f2f2f2",',
       '  nbsVividPink: nbs.colors.vividpink === "#ffb5ba",',
+      '  pokemonFire: pokemon.colors.Fire === "#ee8130",',
       "  hexToRgba: hexToRgba('#ff0000').r === 255,",
       '  rgb: rgbToRgba([1,2,3]).r === 1,',
       '  hsl: hslToRgba({ h: 0, s: 100, l: 50 }).r === 255,',
@@ -284,6 +293,7 @@ maybe('subpath exports resolve', () => {
       reseneTreepoppy: true,
       ncsNeutral: true,
       nbsVividPink: true,
+      pokemonFire: true,
       hexToRgba: true,
       rgb: true,
       hsl: true,

--- a/test/subpathExports.test.ts
+++ b/test/subpathExports.test.ts
@@ -148,6 +148,14 @@ maybe('subpath exports resolve', () => {
     expect(m.werner.defaultMetric).toBe('deltaE2000');
   });
 
+  it('chromonym/tailwind exports the tailwind palette object', async () => {
+    const m = await import('../dist/palettes/tailwind.js');
+    expect(m.tailwind.name).toBe('tailwind');
+    expect(m.tailwind.colors['slate-500']).toBe('#62748e');
+    expect(Object.keys(m.tailwind.colors).length).toBe(242);
+    expect(m.tailwind.defaultMetric).toBe('deltaEok');
+  });
+
   it('chromonym/conversions/hex exports hexToRgba / rgbaToHex', async () => {
     const m = await import('../dist/conversions/hex.js');
     expect(m.hexToRgba('#ff0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
@@ -243,6 +251,7 @@ maybe('subpath exports resolve', () => {
       "const { nbs } = await import('chromonym/nbs');",
       "const { pokemon } = await import('chromonym/pokemon');",
       "const { werner } = await import('chromonym/werner');",
+      "const { tailwind } = await import('chromonym/tailwind');",
       "const { hexToRgba } = await import('chromonym/conversions/hex');",
       "const { rgbToRgba } = await import('chromonym/conversions/rgb');",
       "const { hslToRgba } = await import('chromonym/conversions/hsl');",
@@ -267,6 +276,7 @@ maybe('subpath exports resolve', () => {
       '  nbsVividPink: nbs.colors.vividpink === "#ffb5ba",',
       '  pokemonFire: pokemon.colors.Fire === "#ee8130",',
       '  wernerPrussian: werner.colors["Prussian Blue"] === "#1c1949",',
+      '  tailwindSlate: tailwind.colors["slate-500"] === "#62748e",',
       "  hexToRgba: hexToRgba('#ff0000').r === 255,",
       '  rgb: rgbToRgba([1,2,3]).r === 1,',
       '  hsl: hslToRgba({ h: 0, s: 100, l: 50 }).r === 255,',
@@ -304,6 +314,7 @@ maybe('subpath exports resolve', () => {
       nbsVividPink: true,
       pokemonFire: true,
       wernerPrussian: true,
+      tailwindSlate: true,
       hexToRgba: true,
       rgb: true,
       hsl: true,


### PR DESCRIPTION
## Summary

Four new built-in palettes from the Tier 1 palette-issue backlog, each as its own atomic commit with `feat(palettes):` so semantic-release cuts a minor per palette on merge. ~586 entries added across the four palettes; no existing palette or library API touched. The fourth (RAL) also fills the demo tile grid to a clean 4×4.

| Palette | Issue | Entries | Source | Trademark posture |
|---|---|---|---|---|
| `pokemon` | #30 | 18 | Bulbapedia type-badge colors | Nominative reference; trademark held by Nintendo / Game Freak / The Pokémon Company |
| `werner` | #21 | 110 | Nicholas Rougeux's CC BY 4.0 digitization at c82.net/werner | Public-domain 1821 text; CC-BY attribution required |
| `tailwind` | #25 | 242 (22 × 11) | Tailwind CSS v4.0 default theme, OKLCH spec converted to sRGB hex | MIT-licensed; pinned to v4.0 |
| `ral` | #23 | 216 | MIT-licensed `JohannesVoigt/ral-color-converter` dataset | RAL® trademark held by RAL gGmbH; not for industrial color matching |

Closes #30, #21, #25, #23.

## Changes per palette

Each palette ships the same set of wirings:

1. `src/palettes/<name>.ts` — palette data + JSDoc explaining naming, source, default-metric choice
2. `src/index.ts` — `{ type <Name>ColorName, <name> }` re-export
3. `package.json` — subpath export `chromonym/<name>` (consumers can `import { pokemon } from 'chromonym/pokemon'` for a minimal bundle)
4. `test/palettes.test.ts` — row in the table-driven test (entry count, hex shape, normalizer round-trip, spot checks, metric, name)
5. `test/subpathExports.test.ts` — both the dist-path import test and the real-Node ESM subpath test
6. `demo/src/components/PaletteGrid.tsx` and `PaletteTiles.tsx` — palette registry, label, description, and tile color
7. `NOTICE.md` — attribution / trademark section

## Default-metric choices

- `pokemon` → `deltaE76`. 18 entries; metric choice is academic.
- `werner` → `deltaE2000`. Muted earth-tone distribution rewards perceptual-uniform comparisons.
- `tailwind` → `deltaEok`. Tailwind defines shades on an OKLCH lightness ramp; OKLAB-based distance recovers that structure better than CIELAB76.
- `ral` → `deltaE2000`. The 7000 greys cluster densely across the achromatic axis; CIEDE2000's hue/chroma compensation picks better neighbors than the cheaper deltaE76.

## Tailwind OKLCH→sRGB conversion

Tailwind v4 shipped its first OKLCH-native default theme; the v4.0 source defines colors in OKLCH, not hex. This palette converts those OKLCH values to sRGB hex via Björn Ottosson's reference OKLAB→linear sRGB matrix and the standard IEC 61966-2-1 sRGB transfer function. Out-of-sRGB-gamut values (notably some saturated 500–600 shades in red / orange / pink / rose) are clamped to [0, 1] before hex encoding; wide-gamut-aware browsers render brighter than the shipped hex.

Tailwind v4.2+ added `mauve`, `olive`, `mist`, `taupe` — intentionally excluded; this palette pins to v4.0.

## Werner attribution

The 1821 text (Patrick Syme's adaptation of Abraham Werner) is public domain. The sRGB hex values come from Nicholas Rougeux's CC BY 4.0 photographic digitization of the original chip swatches at <https://www.c82.net/werner/>. Downstream redistributors of the `werner` palette must preserve the Rougeux attribution.

## RAL keying decision

RAL is keyed by code (`'RAL 1000'`, `'RAL 9023'`) rather than by English color name. This mirrors how Pantone is keyed (`'185 C'`) — industrial users reach for the code first, and English names are translations of the German originals (which are themselves the primary reference). The English name is preserved as an inline source comment on every entry so anyone reading `src/palettes/ral.ts` sees the human-readable form at a glance. A future addition could ship `chromonym/ral-by-name` as a secondary export if there's demand.

## Testing

- `bun run check` clean end-to-end after each of the four commits (Biome, ESLint react-compiler + react-hooks, typecheck × 3, build, 472+ tests, demo build, knip, publint + attw).
- Playwright validation of the demo at `localhost:5173`: all 16 palette tiles (12 existing + 4 new) render and select cleanly, no console/page errors, swatch grid populates for each new palette. `identify()` returns `psychic` / `lake red` / `pink-600` / `ral 4010` (Telemagenta) for the default `#e20074` preset across the four new palettes — different nearest-name per palette confirms each is wired through the indexing path, not just present statically.
- The four added palettes fill the demo's palette-tile grid to a complete 4 × 4 = 16 tiles, which is the inflection point flagged for a future demo-layout pass (deferred per the PR scope).

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated — each palette has a row in `test/palettes.test.ts` and entries in `test/subpathExports.test.ts`
- [x] README / JSDoc updated — each palette has rich JSDoc; the demo registry strings explain each new palette's scope
- [x] `bun run lint && bun run typecheck && bun test` passes locally — full `bun run check` is green
