### PR TITLE
chore(deps): bump pinned actions group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Lint, Typecheck, Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.1
@@ -69,7 +69,7 @@ jobs:
         if: >
           github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5.5.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -95,12 +95,12 @@ jobs:
       # ruleset bypass list; the default GITHUB_TOKEN is not.
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.1

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,7 +21,7 @@ jobs:
     name: Check markdown links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Link check (lychee)
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Bumps the SHA-pinned GitHub Actions group and corrects two version comments that have been mislabeled against their SHAs since aa34847.

## Changes
- `actions/checkout` 6.0.2 -> 6.0.3 (5 occurrences: ci, deploy-demo, link-check, and scorecard)
- `codecov/codecov-action` 6.0.0 -> 7.0.0
- `actions/create-github-app-token` 3.1.1 -> 3.2.0
- Fix the stale `# v4.2.2` (checkout) and `# v5.5.0` (codecov) comments so they match the pinned SHAs

## Notes
- All new SHAs were verified against the upstream release tags.
- `codecov/codecov-action` v7.0.0 is a major bump only because of a GPG key rotation (keybase migration to the `codecovsecops` account). The functional delta over the currently pinned 6.0.0 is the v6.0.1 template-injection fix (VULN-1652) plus removal of the action's internal license-compliance workflow; the inputs used here (`token`, `files`, and `fail_ci_if_error`) are unchanged.
- `actions/create-github-app-token` 3.2.0 adds private-key input validation; the inputs used here (`app-id` and `private-key`) are unchanged.

Supersedes #38, Dependabot's grouped bump, which carried the same SHAs but perpetuated the mislabeled comments.

## Testing
CI (lint, typecheck, test, and package hygiene) runs on this PR. The bumps are CI-only and do not touch shipped package code, so they trigger no semantic-release publish.