### PR TITLE
chore(deps): bump demo typescript to 6.0

### DIFF
--- a/demo/bun.lock
+++ b/demo/bun.lock
@@ -23,7 +23,7 @@
         "eslint-plugin-react-compiler": "19.1.0-rc.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "tailwindcss": "^4.3.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^8.1.4",
       },
     },
@@ -1017,7 +1017,7 @@
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "tailwindcss": "^4.3.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.1.4"
   }
 }


### PR DESCRIPTION
Companion to #42, which put the library root on TypeScript 7.

## What changed
- demo `typescript` `^5.9.3` → `^6.0.3`, the ceiling of `@typescript-eslint/typescript-estree`'s peer range (`>=4.8.4 <6.1.0`); the demo cannot take TS 7 until typescript-eslint ports to the native API, whose bare `typescript` entry no longer exposes the JS API their parser loads at import time
- no tsconfig changes needed: the demo config carries none of the options TS 6 deprecates and TS 7 removes (`baseUrl`, prologue-era module modes)

## Testing
`bun run check` passes locally: biome, demo ESLint (react-compiler), typecheck (tsc 7), demo typecheck (TS 6.0.3), build, test typecheck, bun test, demo build, knip, publint + attw.