### PR TITLE
fix(ci): drop --exclude-mail, removed in lychee 0.24

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -26,14 +26,13 @@ jobs:
       - name: Link check (lychee)
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          # Skip GitHub's per-IP rate-limited API endpoints (shields.io
-          # badges, codecov.io graphs) and any localhost dev refs; those
-          # return flaky 429s under a cold cache on CI runners.
+          # Skip hosts that reject link checkers rather than 404: shields.io
+          # and codecov.io rate-limit per IP under a cold CI cache, and
+          # npmjs.com answers bots with 403.
           args: >-
             --verbose
             --no-progress
             --max-retries 2
-            --exclude-mail
-            --exclude '^https?://(img\.shields\.io|codecov\.io)'
+            --exclude '^https?://(img\.shields\.io|codecov\.io|www\.npmjs\.com)'
             './**/*.md'
           fail: true


### PR DESCRIPTION
**The link-check workflow is currently broken on main.** The lychee-action v2.9.0 bump in #46 moves the default lychee from 0.23.0 to 0.24.2, and 0.24 **removed `--exclude-mail`**. It is now a hard argument error:

```
error: unexpected argument '--exclude-mail' found
  tip: a similar argument exists: '--include-mail'
```

The job is scheduled monthly, so this would have gone unnoticed until the 1st. Mail links are excluded by default in 0.24, so dropping the flag preserves the behavior.

Also excludes `npmjs.com`, which answers link checkers with 403 (both README badge links failed).

## One real finding this does not fix

`NOTICE.md` attributes the `pantone` palette to [`draganradu/color_library`](https://github.com/draganradu/color_library), which now **404s**. The author's account still exists and has a plausible successor repo (`simple-color-convertor-pantone-ral`, MIT, same author), but I did not repoint the link: this is an attribution and licensing statement, and silently swapping the cited source on an inference is worse than a dead link. Needs a human decision.

Verified locally with lychee 0.24.2: 171 unique links, that NOTICE.md 404 the only remaining error.